### PR TITLE
build: fix failing test WithinMethodGCTest + better error reporting

### DIFF
--- a/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/WithinMethodGCTest.kt
+++ b/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/WithinMethodGCTest.kt
@@ -101,5 +101,17 @@ class WithinMethodGCTest : Harness("undertest-junit5") {
     ut_mirror().lineWith("root").uncomment()
     ut_mirror().lineWith("selfie2()").commentOut()
     ut_mirror().lineWith("selfie()").uncomment()
+    gradleWriteSS()
+    ut_snapshot()
+        .assertContent(
+            """
+      ╔═ selfie ═╗
+      root
+      ╔═ selfie/leaf ═╗
+      maple
+      ╔═ [end of file] ═╗
+      
+    """
+                .trimIndent())
   }
 }

--- a/undertest-junit5/src/test/kotlin/undertest/junit5/__snapshots__/UT_WithinMethodGCTest.ss
+++ b/undertest-junit5/src/test/kotlin/undertest/junit5/__snapshots__/UT_WithinMethodGCTest.ss
@@ -1,3 +1,5 @@
-╔═ selfie2/leaf ═╗
+╔═ selfie ═╗
+root
+╔═ selfie/leaf ═╗
 maple
 ╔═ [end of file] ═╗


### PR DESCRIPTION
- We weren't synching test state with snapshhot for WithinMethodGCTest
- On Harness find the first failing test and report that. So `ReadWriteTest` was failing bc the `UT_WithinMethodGCTest` error