### PR TITLE
Add bin/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .gradle/
 build/
+bin/


### PR DESCRIPTION
Cloning the repo and launching in VSCode created a bunch of files in `/selfie-runner-junit5/bin` and `undertest-junit5/bin`. This ignores them. Please advise if this is not the right approach.