### PR TITLE
Fix selfie methods to be `@JvmStatic` and have easy access from Java

### DIFF
--- a/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/Selfie.kt
+++ b/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/Selfie.kt
@@ -18,78 +18,88 @@ package com.diffplug.selfie
 import com.diffplug.selfie.junit5.Router
 import org.opentest4j.AssertionFailedError
 
-/**
- * Sometimes a selfie is environment-specific, but should not be deleted when run in a different
- * environment.
- */
-fun preserveSelfiesOnDisk(vararg subsToKeep: String): Unit {
-  if (subsToKeep.isEmpty()) {
-    Router.readOrWriteOrKeep(null, null)
-  } else {
-    for (sub in subsToKeep) {
-      Router.readOrWriteOrKeep(null, sub)
-    }
-  }
-}
-
-open class DiskSelfie internal constructor(private val actual: Snapshot) {
-  fun toMatchDisk(sub: String = ""): Snapshot {
-    val onDisk = Router.readOrWriteOrKeep(actual, sub)
-    if (RW.isWrite) return actual
-    else if (onDisk == null) throw AssertionFailedError("No such snapshot")
-    else if (actual.value != onDisk.value)
-        throw AssertionFailedError("Snapshot failure", onDisk.value, actual.value)
-    else if (actual.lenses.keys != onDisk.lenses.keys)
-        throw AssertionFailedError(
-            "Snapshot failure: mismatched lenses", onDisk.lenses.keys, actual.lenses.keys)
-    for (key in actual.lenses.keys) {
-      val actualValue = actual.lenses[key]!!
-      val onDiskValue = onDisk.lenses[key]!!
-      if (actualValue != onDiskValue) {
-        throw AssertionFailedError("Snapshot failure within lens $key", onDiskValue, actualValue)
+object Selfie {
+  /**
+   * Sometimes a selfie is environment-specific, but should not be deleted when run in a different
+   * environment.
+   */
+  @JvmStatic
+  fun preserveSelfiesOnDisk(vararg subsToKeep: String): Unit {
+    if (subsToKeep.isEmpty()) {
+      Router.readOrWriteOrKeep(null, null)
+    } else {
+      for (sub in subsToKeep) {
+        Router.readOrWriteOrKeep(null, sub)
       }
     }
-    // if we're in read mode and the equality checks passed, stick with the disk value
-    return onDisk
   }
-}
-fun <T> expectSelfie(actual: T, snapshotter: Snapshotter<T>) =
-    DiskSelfie(snapshotter.snapshot(actual))
 
-class StringSelfie(private val actual: String) : DiskSelfie(Snapshot.of(actual)) {
-  fun toBe(expected: String): String = TODO()
-  fun toBe_TODO(): String = TODO()
-}
-fun expectSelfie(actual: String) = StringSelfie(actual)
+  open class DiskSelfie internal constructor(private val actual: Snapshot) {
+    fun toMatchDisk(sub: String = ""): Snapshot {
+      val onDisk = Router.readOrWriteOrKeep(actual, sub)
+      if (RW.isWrite) return actual
+      else if (onDisk == null) throw AssertionFailedError("No such snapshot")
+      else if (actual.value != onDisk.value)
+          throw AssertionFailedError("Snapshot failure", onDisk.value, actual.value)
+      else if (actual.lenses.keys != onDisk.lenses.keys)
+          throw AssertionFailedError(
+              "Snapshot failure: mismatched lenses", onDisk.lenses.keys, actual.lenses.keys)
+      for (key in actual.lenses.keys) {
+        val actualValue = actual.lenses[key]!!
+        val onDiskValue = onDisk.lenses[key]!!
+        if (actualValue != onDiskValue) {
+          throw AssertionFailedError("Snapshot failure within lens $key", onDiskValue, actualValue)
+        }
+      }
+      // if we're in read mode and the equality checks passed, stick with the disk value
+      return onDisk
+    }
+  }
 
-class BinarySelfie(private val actual: ByteArray) : DiskSelfie(Snapshot.of(actual)) {
-  fun toBeBase64(expected: String): ByteArray = TODO()
-  fun toBeBase64_TODO(): ByteArray = TODO()
-}
-fun expectSelfie(actual: ByteArray) = BinarySelfie(actual)
+  @JvmStatic
+  fun <T> expectSelfie(actual: T, snapshotter: Snapshotter<T>) =
+      DiskSelfie(snapshotter.snapshot(actual))
 
-class IntSelfie(private val actual: Int) {
-  fun toBe(expected: Int): Int = TODO()
-  fun toBe_TODO(): Int = TODO()
-}
-fun expectSelfie(actual: Int) = IntSelfie(actual)
+  class StringSelfie(private val actual: String) : DiskSelfie(Snapshot.of(actual)) {
+    fun toBe(expected: String): String = TODO()
+    fun toBe_TODO(): String = TODO()
+  }
 
-class LongSelfie(private val actual: Long) {
-  fun toBe(expected: Long): Long = TODO()
-  fun toBe_TODO(): Long = TODO()
-}
-fun expectSelfie(actual: Long) = LongSelfie(actual)
+  @JvmStatic fun expectSelfie(actual: String) = StringSelfie(actual)
 
-class BooleanSelfie(private val actual: Boolean) {
-  fun toBe(expected: Boolean): Boolean = TODO()
-  fun toBe_TODO(): Boolean = TODO()
-}
-fun expectSelfie(actual: Boolean) = BooleanSelfie(actual)
+  class BinarySelfie(private val actual: ByteArray) : DiskSelfie(Snapshot.of(actual)) {
+    fun toBeBase64(expected: String): ByteArray = TODO()
+    fun toBeBase64_TODO(): ByteArray = TODO()
+  }
 
-// infix versions for the inline methods, consistent with Kotest's API
-infix fun String.shouldBeSelfie(expected: String): String = expectSelfie(this).toBe(expected)
-infix fun ByteArray.shouldBeSelfieBase64(expected: String): ByteArray =
-    expectSelfie(this).toBeBase64(expected)
-infix fun Int.shouldBeSelfie(expected: Int): Int = expectSelfie(this).toBe(expected)
-infix fun Long.shouldBeSelfie(expected: Long): Long = expectSelfie(this).toBe(expected)
-infix fun Boolean.shouldBeSelfie(expected: Boolean): Boolean = expectSelfie(this).toBe(expected)
+  @JvmStatic fun expectSelfie(actual: ByteArray) = BinarySelfie(actual)
+
+  class IntSelfie(private val actual: Int) {
+    fun toBe(expected: Int): Int = TODO()
+    fun toBe_TODO(): Int = TODO()
+  }
+
+  @JvmStatic fun expectSelfie(actual: Int) = IntSelfie(actual)
+
+  class LongSelfie(private val actual: Long) {
+    fun toBe(expected: Long): Long = TODO()
+    fun toBe_TODO(): Long = TODO()
+  }
+
+  @JvmStatic fun expectSelfie(actual: Long) = LongSelfie(actual)
+
+  class BooleanSelfie(private val actual: Boolean) {
+    fun toBe(expected: Boolean): Boolean = TODO()
+    fun toBe_TODO(): Boolean = TODO()
+  }
+
+  @JvmStatic fun expectSelfie(actual: Boolean) = BooleanSelfie(actual)
+
+  // infix versions for the inline methods, consistent with Kotest's API
+  infix fun String.shouldBeSelfie(expected: String): String = expectSelfie(this).toBe(expected)
+  infix fun ByteArray.shouldBeSelfieBase64(expected: String): ByteArray =
+      expectSelfie(this).toBeBase64(expected)
+  infix fun Int.shouldBeSelfie(expected: Int): Int = expectSelfie(this).toBe(expected)
+  infix fun Long.shouldBeSelfie(expected: Long): Long = expectSelfie(this).toBe(expected)
+  infix fun Boolean.shouldBeSelfie(expected: Boolean): Boolean = expectSelfie(this).toBe(expected)
+}

--- a/undertest-junit5/src/test/kotlin/undertest/junit5/UT_CarriageReturnTest.kt
+++ b/undertest-junit5/src/test/kotlin/undertest/junit5/UT_CarriageReturnTest.kt
@@ -1,6 +1,6 @@
 package undertest.junit5
 
-import com.diffplug.selfie.expectSelfie
+import com.diffplug.selfie.Selfie.expectSelfie
 import kotlin.test.Test
 
 class UT_CarriageReturnTest {

--- a/undertest-junit5/src/test/kotlin/undertest/junit5/UT_DuplicateWriteTest.kt
+++ b/undertest-junit5/src/test/kotlin/undertest/junit5/UT_DuplicateWriteTest.kt
@@ -1,6 +1,6 @@
 package undertest.junit5
 
-import com.diffplug.selfie.expectSelfie
+import com.diffplug.selfie.Selfie.expectSelfie
 import org.junit.jupiter.api.Test
 
 class UT_DuplicateWriteTest {

--- a/undertest-junit5/src/test/kotlin/undertest/junit5/UT_MethodLevelGCTest.kt
+++ b/undertest-junit5/src/test/kotlin/undertest/junit5/UT_MethodLevelGCTest.kt
@@ -1,6 +1,6 @@
 package undertest.junit5
 // spotless:off
-import com.diffplug.selfie.expectSelfie
+import com.diffplug.selfie.Selfie.expectSelfie
 import kotlin.test.Test
 // spotless:on
 

--- a/undertest-junit5/src/test/kotlin/undertest/junit5/UT_ReadWriteTest.kt
+++ b/undertest-junit5/src/test/kotlin/undertest/junit5/UT_ReadWriteTest.kt
@@ -1,6 +1,6 @@
 package undertest.junit5
 
-import com.diffplug.selfie.expectSelfie
+import com.diffplug.selfie.Selfie.expectSelfie
 import kotlin.test.Test
 
 class UT_ReadWriteTest {

--- a/undertest-junit5/src/test/kotlin/undertest/junit5/UT_WithinMethodGCTest.kt
+++ b/undertest-junit5/src/test/kotlin/undertest/junit5/UT_WithinMethodGCTest.kt
@@ -1,6 +1,6 @@
 package undertest.junit5
 // spotless:off
-import com.diffplug.selfie.expectSelfie
+import com.diffplug.selfie.Selfie.expectSelfie
 import kotlin.test.Test
 
 // spotless:on


### PR DESCRIPTION
Since all our tests are Kotlin, I had some surprises as I onboarded a big Java project.