### PR TITLE
Improve callstack capture and IDE-compatible printing

### DIFF
--- a/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/WriteTracker.kt
+++ b/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/WriteTracker.kt
@@ -17,30 +17,48 @@ package com.diffplug.selfie.junit5
 
 import com.diffplug.selfie.RW
 import com.diffplug.selfie.Snapshot
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.stream.Collectors
+import kotlin.io.path.name
 
 /** Represents the line at which user code called into Selfie. */
-data class CallLocation(val subpath: String, val line: Int) : Comparable<CallLocation> {
-  override fun compareTo(other: CallLocation): Int {
-    val subpathCompare = subpath.compareTo(other.subpath)
-    return if (subpathCompare != 0) subpathCompare else line.compareTo(other.line)
+data class CallLocation(val clazz: String, val method: String, val file: String?, val line: Int) :
+    Comparable<CallLocation> {
+  override fun compareTo(other: CallLocation): Int =
+      compareValuesBy(this, other, { it.clazz }, { it.method }, { it.file }, { it.line })
+
+  /**
+   * If the runtime didn't give us the filename, guess it from the class, and try to find the source
+   * file by walking the CWD. If we don't find it, report it as a `.class` file.
+   */
+  private fun findFileIfAbsent(): String {
+    if (file != null) {
+      return file
+    }
+    val fileWithoutExtension = clazz.substringAfterLast('.').substringBefore('$')
+    val likelyExtensions = listOf("kt", "java", "scala", "groovy", "clj", "cljc")
+    val filenames = likelyExtensions.map { "$fileWithoutExtension.$it" }.toSet()
+    val firstPath = Files.walk(Paths.get("")).use { it.filter { it.name in filenames }.findFirst() }
+    return if (firstPath.isEmpty) "${clazz.substringAfterLast('.')}.class" else firstPath.get().name
   }
-  override fun toString(): String = "$subpath:$line"
+
+  /** A `toString` which an IDE will render as a clickable link. */
+  override fun toString(): String = "$clazz.$method(${findFileIfAbsent()}:$line)"
 }
 /** Represents the callstack above a given CallLocation. */
 class CallStack(val location: CallLocation, val restOfStack: List<CallLocation>) {
-  override fun toString(): String = "$location"
+  override fun toString(): String {
+    return location.toString()
+  }
 }
-/**
- * Generates a CallLocation and the CallStack behind it, starting at the entrypoint into the Selfie
- * codebase.
- */
+/** Generates a CallLocation and the CallStack behind it. */
 fun recordCall(): CallStack {
   val calls =
       StackWalker.getInstance().walk { frames ->
         frames
             .dropWhile { it.className.startsWith("com.diffplug.selfie") }
-            .map { CallLocation(it.className.replace('.', '/') + ".kt", it.lineNumber) }
+            .map { CallLocation(it.className, it.methodName, it.fileName, it.lineNumber) }
             .collect(Collectors.toList())
       }
   return CallStack(calls.removeAt(0), calls)
@@ -56,7 +74,7 @@ internal open class WriteTracker<K : Comparable<K>, V> {
     if (existing != null) {
       if (existing.snapshot != snapshot) {
         throw org.opentest4j.AssertionFailedError(
-            "Snapshot was set to multiple values:\nfirst time:${existing.callStack}\n\nthis time:${call}",
+            "Snapshot was set to multiple values!\n  first time: ${existing.callStack}\n   this time: ${call}",
             existing.snapshot,
             snapshot)
       } else if (RW.isWriteOnce) {

--- a/selfie-runner-junit5/src/test/kotlin/testpkg/RecordCallTest.kt
+++ b/selfie-runner-junit5/src/test/kotlin/testpkg/RecordCallTest.kt
@@ -24,7 +24,8 @@ class RecordCallTest {
   @Test
   fun testRecordCall() {
     val stack = recordCall()
-    stack.location.toString() shouldBe "testpkg/RecordCallTest.kt:26"
+    // shows as clickable link in IDE
+    stack.location.toString() shouldBe "testpkg.RecordCallTest.testRecordCall(RecordCallTest.kt:26)"
     stack.restOfStack.size shouldBeGreaterThan 0
   }
 }


### PR DESCRIPTION
When we annotate a duplicate-write error with callstacks, we want it to create a clickable link within an IDE. We weren't capturing enough data before, now we are.