### PR TITLE
API for implicit selfies (bad idea)

### DIFF
--- a/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/Selfie.kt
+++ b/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/Selfie.kt
@@ -48,6 +48,8 @@ object Selfie {
   fun <T> expectSelfie(actual: T, snapshotter: Snapshotter<T>) =
       DiskSelfie(snapshotter.snapshot(actual))
 
+  @JvmStatic fun expectSelfie(actual: Any) = expectSelfie(actual, Router.snapshotImplicit(actual))
+
   class StringSelfie(private val actual: String) : DiskSelfie(Snapshot.of(actual)) {
     fun toBe(expected: String): String = TODO()
     fun toBe_TODO(): String = TODO()

--- a/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieSettingsAPI.kt
+++ b/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieSettingsAPI.kt
@@ -15,11 +15,16 @@
  */
 package com.diffplug.selfie.junit5
 
+import com.diffplug.selfie.Snapshotter
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
 interface SelfieSettingsAPI {
+  /** API function which allows user to specify a custom snapshotter. */
+  fun implictSnapshotterFor(underTest: Any): Snapshotter<*> =
+      throw AssertionError("Implicit snapshots have not been setup, see TODO.")
+
   /**
    * Defaults to `__snapshot__`, null means that snapshots are stored at the same folder location as
    * the test that created them.

--- a/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
+++ b/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
@@ -50,6 +50,10 @@ internal object Router {
       ExpectedActual(cm.clazz.read(cm.method, suffix), actual)
     }
   }
+  fun snapshotImplicit(actual: Any): Snapshotter<Any> {
+    val cm = classAndMethod()
+    return cm.clazz.parent.settings.implictSnapshotterFor(actual) as Snapshotter<Any>
+  }
   fun keep(subOrKeepAll: String?) {
     val cm = classAndMethod()
     if (subOrKeepAll == null) {


### PR DESCRIPTION
I'm pushing this up just to document an idea which turned out to be bad.

For my Selfie usecase, I am often snapshotting two things:

- `io.restassured.response.Response` which models everything about an HTTP response (content, cookies, headers, etc)
- `common.EmailAssert` an in-house data structure which models everything about an email (content, subject, etc)

I made a custom `Snapshotter<T>` for each of them

```kotlin
object TSelfie {
	object Response : Snapshotter<io.restassured.response.Response> { ... }
	object Email : Snapshotter<common.EmailDev> { ... }
```

but it was a pain to write out `expectSelfie(somePage, TSelfie.Response)` everywhere, so I tried the approach in this PR.

This turns out to be a bad approach, because a much better approach is

```kotlin
object TSelfie {
	object Response : Snapshotter<io.restassured.response.Response> {
		override fun snapshot(value: io.restassured.response.Response) = ...
		@JvmStatic
		fun expectSelfie(value: io.restassured.response.Response) = Selfie.expectSelfie(value, this)
	}

	object Email : Snapshotter<EmailAssert> {
		override fun snapshot(value: EmailAssert) = ...
		@JvmStatic fun expectSelfie(value: EmailAssert) = Selfie.expectSelfie(value, this)
	}
}
```

and then in a test I just do:

```
import static mypkg.TSelfie.Response.expectSelfie
import static mypkg.TSelfie.Email.expectSelfie
import static com.diffplug.selfie.expectSelfie
```

And I now I get seamless syntax and type-checking without any fanciness from Selfie.