### PR TITLE
Implement the `interactive` mode

### DIFF
--- a/docs/src/pages/jvm/get-started.mdx
+++ b/docs/src/pages/jvm/get-started.mdx
@@ -10,8 +10,8 @@ If you're using Maven, add the following dependency to your `pom.xml` file:
 
 ```xml
 <dependency>
-    <groupId>com.yourdomain.selfie</groupId>
-    <artifactId>selfie</artifactId>
+    <groupId>com.diffplug.selfie</groupId>
+    <artifactId>selfie-runner-junit5</artifactId>
     <version>LATEST_VERSION</version>
     <scope>test</scope>
 </dependency>
@@ -23,66 +23,90 @@ Replace `LATEST_VERSION` with the latest available version of Selfie.
 
 For Gradle users, add this to your `build.gradle` file:
 
-```bash
-testImplementation 'com.yourdomain.selfie:selfie:LATEST_VERSION'
+```groovy
+testImplementation 'com.diffplug.selfie:selfie-runner-junit5:LATEST_VERSION'
 ```
 
 Again, replace `LATEST_VERSION` with the latest available version of Selfie.
 
-## Basic usage
+## Quickstart
 
-1. Capture a Snapshot:
+Let's say we have the following test code:
 
-   Before you can use the snapshot testing, you need to capture an initial snapshot. This will be used as a reference for future tests.
+```java
+expectSelfie(List.of(1, 2, 3).toString()).toBe_TODO();
+```
 
-   ```java
-   import com.yourdomain.selfie.Selfie;
+If you run this test, Selfie will rewrite your sourcecode to be this:
 
-   public class YourTestClass {
-       @Test
-       public void yourTestMethod() {
-           String output = someFunctionThatReturnsAString();
-           Selfie.capture(output);
-       }
-   }
-   ```
+```java
+expectSelfie(List.of(1, 2, 3).toString()).toBe("[1, 2, 3]");
+```
 
-2. Compare with Snapshot:
+Now, let's change the code to this:
 
-   Once you've captured the initial snapshot, subsequent test runs will automatically compare the current output with the saved snapshot.
+```java
+expectSelfie(List.of(42).toString()).toBe("[1, 2, 3]");
+```
 
-   ```java
-   import com.yourdomain.selfie.Selfie;
+When we run the test, we will get a failure, and the failure message will be:
 
-   public class YourTestClass {
-       @Test
-       public void yourTestMethod() {
-           String output = someFunctionThatReturnsAString();
-           Selfie.assertEqualsWithSnapshot(output);
-       }
-   }
-   ```
+```
+Snapshot failure
+```
 
-   If the output differs from the saved snapshot, `assertEqualsWithSnapshot` will fail, pointing out the differences.
+As you can see, we have three options:
 
-3. Update a Snapshot:
+- rename `toBe` to `toBe_TODO` (you can leave the `"[1, 2, 3]"` or remove it, makes no difference)
+  - selfie will rewrite only this one snapshot, and selfie will remove the `_TODO`
+- put `//selfieonce` anywhere in the file
+  - this will rewrite all snapshots in the file, and Selfie will remove `//selfieonce` after it has done so
+- put `//SELFIEWRITE` anywhere in that file
+  - this will rewrite all snapshots in the file until you remove `//SELFIEWRITE` yourself
 
-   If you made intentional changes to the application output and want to update the snapshot, you can do so with:
+If you choose `selfieonce`, the comment will be removed after the first run. If you choose `SELFIEWRITE`, then all snapshots in that file will be silently updated, and Selfie will not automatically remove the comment.
 
-   ```java
-   Selfie.updateSnapshot(output);
-   ```
+## Disk
 
-## Tips and tricks
+To store a snapshot on disk, swap `toBe` for `toMatchDisk`:
 
-Folder Structure: By default, Selfie saves snapshots in a directory named `__snapshots__` alongside your test files. Ensure you check this into your version control to keep reference snapshots consistent across different environments.
+```java
+expectSelfie(List.of(1, 2, 3).toString()).toMatchDisk_TODO();
+```
 
-Named Snapshots: You can name your snapshots to make it easier to identify them, especially if you have multiple snapshots in one test class.
+This will create a file called `SomethingOrOther.ss` in the same directory as your test. It will also rewrite the test source to
 
-## Contribute
+```java
+expectSelfie(List.of(1, 2, 3).toString()).toMatchDisk();
+```
 
-Selfie is open source and we welcome contributions! Check out the project on [GitHub](https://github.com/diffplug/selfie), raise issues, or submit pull requests.
+Just like inline snapshots, you can use  `_TODO`, `//selfieonce`, and `//SELFIEWRITE` to control how the snapshots are written and updated. You never have to use `_TODO` if you have the `//selfieonce` or `//SELFIEWRITE` comments in your file.
 
----
+If you want the disk snapshots to live in a different folder, TODO.
 
-We hope this guide has helped you get started with Selfie. Enjoy seamless snapshot testing in Java!
+## Modes
+
+Selfie has three modes:
+
+- `interactive`, the default mode, used in the quickstart above
+- `readonly`, the default mode if a `CI` environment variable is present, will cause tests to fail if `//selfieonce` or `//SELFIEWRITE` are present in the sourcecode
+- `overwrite`, which will cause all snapshots to be overwritten, without looking for `//selfieonce` or `//SELFIEWRITE`
+
+You can manually set the mode by setting the `SELFIE` environment variable or system property to `interactive`, `readonly`, or `overwrite`.
+
+## Reference
+
+- `.toBe_TODO()` or `.toBe_TODO(argumentIsIgnored)`
+  - creates or updates an inline literal snapshot
+- `.toMatchDisk_TODO()`
+  - creates or updates a disk snapshot
+- `//selfieonce`
+  - all snapshots in the file will be updated, whether they are `_TODO` or not.
+  - selfie will remove the comment after the snapshots have updated
+- `//SELFIEWRITE`
+  - all snapshots in the file will be updated, whether they are `_TODO` or not.
+  - selfie will not remove the comment after the snapshots have updated
+- mode is set by the `SELFIE` environment variable or system property
+  - `interactive`, default
+  - `readonly`, default if `CI` environment variable is `true`
+  - `overwrite`, all snapshots can be overwritten

--- a/docs/src/pages/jvm/get-started.mdx
+++ b/docs/src/pages/jvm/get-started.mdx
@@ -17,7 +17,7 @@ If you're using Maven, add the following dependency to your `pom.xml` file:
 </dependency>
 ```
 
-Replace `LATEST_VERSION` with the latest available version of Selfie.
+Replace `LATEST_VERSION` with the latest available version of selfie.
 
 ### Gradle
 
@@ -27,7 +27,7 @@ For Gradle users, add this to your `build.gradle` file:
 testImplementation 'com.diffplug.selfie:selfie-runner-junit5:LATEST_VERSION'
 ```
 
-Again, replace `LATEST_VERSION` with the latest available version of Selfie.
+Again, replace `LATEST_VERSION` with the latest available version of selfie.
 
 ## Quickstart
 
@@ -37,7 +37,7 @@ Let's say we have the following test code:
 expectSelfie(List.of(1, 2, 3).toString()).toBe_TODO();
 ```
 
-If you run this test, Selfie will rewrite your sourcecode to be this:
+If you run this test, selfie will rewrite your sourcecode to be this:
 
 ```java
 expectSelfie(List.of(1, 2, 3).toString()).toBe("[1, 2, 3]");
@@ -60,11 +60,9 @@ As you can see, we have three options:
 - rename `toBe` to `toBe_TODO` (you can leave the `"[1, 2, 3]"` or remove it, makes no difference)
   - selfie will rewrite only this one snapshot, and selfie will remove the `_TODO`
 - put `//selfieonce` anywhere in the file
-  - this will rewrite all snapshots in the file, and Selfie will remove `//selfieonce` after it has done so
+  - this will rewrite all snapshots in the file, and selfie will remove `//selfieonce` after it has done so
 - put `//SELFIEWRITE` anywhere in that file
   - this will rewrite all snapshots in the file until you remove `//SELFIEWRITE` yourself
-
-If you choose `selfieonce`, the comment will be removed after the first run. If you choose `SELFIEWRITE`, then all snapshots in that file will be silently updated, and Selfie will not automatically remove the comment.
 
 ## Disk
 
@@ -82,7 +80,7 @@ expectSelfie(List.of(1, 2, 3).toString()).toMatchDisk();
 
 Just like inline snapshots, you can use  `_TODO`, `//selfieonce`, and `//SELFIEWRITE` to control how the snapshots are written and updated. You never have to use `_TODO` if you have the `//selfieonce` or `//SELFIEWRITE` comments in your file.
 
-If you want the disk snapshots to live in a different folder, TODO.
+If you want the disk snapshots to live in a different folder, set `snapshotFolderName` using [SelfieSettings](https://kdoc.selfie.dev/selfie-runner-junit5/com.diffplug.selfie.junit5/-selfie-settings-a-p-i/).
 
 ## Modes
 
@@ -101,10 +99,10 @@ You can manually set the mode by setting the `SELFIE` environment variable or sy
 - `.toMatchDisk_TODO()`
   - creates or updates a disk snapshot
 - `//selfieonce`
-  - all snapshots in the file will be updated, whether they are `_TODO` or not.
+  - all snapshots in the file will be updated, whether they are `_TODO` or not
   - selfie will remove the comment after the snapshots have updated
 - `//SELFIEWRITE`
-  - all snapshots in the file will be updated, whether they are `_TODO` or not.
+  - all snapshots in the file will be updated, whether they are `_TODO` or not
   - selfie will not remove the comment after the snapshots have updated
 - mode is set by the `SELFIE` environment variable or system property
   - `interactive`, default

--- a/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Mode.kt
+++ b/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Mode.kt
@@ -15,7 +15,17 @@
  */
 package com.diffplug.selfie
 
+import com.diffplug.selfie.guts.CallStack
+import com.diffplug.selfie.guts.SnapshotStorage
+
 enum class Mode {
+  interactive,
   readonly,
-  overwrite
+  overwrite;
+  fun canWrite(isTodo: Boolean, call: CallStack, storage: SnapshotStorage): Boolean =
+      when (this) {
+        interactive -> isTodo || storage.sourceFileHasWritableComment(call)
+        readonly -> false
+        overwrite -> true
+      }
 }

--- a/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Selfie.kt
+++ b/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Selfie.kt
@@ -50,7 +50,7 @@ object Selfie {
     fun toMatchDisk(sub: String = ""): DiskSelfie {
       val call = recordCall()
       val writable = storage.mode.canWrite(false, call, storage)
-      val comparison = storage.readWriteDisk(actual, sub, call)
+      val comparison = storage.readWriteDisk(writable, actual, sub, call)
       if (!writable) {
         comparison.assertEqual(storage.fs)
       }
@@ -64,7 +64,7 @@ object Selfie {
       if (!writable) {
         throw storage.fs.assertFailed("Can't call `toMatchDisk_TODO` in ${Mode.readonly} mode!")
       }
-      storage.readWriteDisk(actual, sub, call)
+      storage.readWriteDisk(writable, actual, sub, call)
       storage.writeInline(DiskSnapshotTodo.createLiteral(), call)
       return this
     }

--- a/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/CommentTracker.kt
+++ b/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/CommentTracker.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.selfie.guts
+
+import com.diffplug.selfie.ArrayMap
+
+internal expect class CAS<T> {
+  fun get(): T
+  fun updateAndGet(update: (T) -> T): T
+}
+
+internal expect fun <T> createCas(initial: T): CAS<T>
+
+/**
+ * Tracks whether a given file has a comment which allows it to be written to. Thread-safe on
+ * multithreaded platforms.
+ */
+class CommentTracker {
+  private enum class WritableComment {
+    NO_COMMENT,
+    ONCE,
+    FOREVER;
+    val writable: Boolean
+      get() = this != NO_COMMENT
+    val needsRemoval: Boolean
+      get() = this == ONCE
+  }
+  private val cache = createCas(ArrayMap.empty<Path, WritableComment>())
+  fun pathsWithOnce(): Iterable<Path> =
+      cache.get().mapNotNull { if (it.value == WritableComment.ONCE) it.key else null }
+  fun hasWritableComment(call: CallStack, layout: SnapshotFileLayout): Boolean {
+    val path = layout.sourcePathForCall(call.location) ?: return false
+    val comment = cache.get()[path]
+    return if (comment != null) {
+      comment.writable
+    } else {
+      val str = layout.fs.fileRead(path)
+      // TODO: there is a bug here due to string constants, and non-C file comments
+      val newComment =
+          if (str.contains("//selfieonce") || str.contains("// selfieonce")) {
+            WritableComment.ONCE
+          } else if (str.contains("//SEFLIEWRITE") || str.contains("// SELFIEWRITE")) {
+            WritableComment.FOREVER
+          } else {
+            WritableComment.NO_COMMENT
+          }
+      cache.updateAndGet { it.plus(path, newComment) }
+      newComment.writable
+    }
+  }
+}

--- a/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/CommentTracker.kt
+++ b/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/CommentTracker.kt
@@ -52,7 +52,7 @@ class CommentTracker {
       val newComment =
           if (str.contains("//selfieonce") || str.contains("// selfieonce")) {
             WritableComment.ONCE
-          } else if (str.contains("//SEFLIEWRITE") || str.contains("// SELFIEWRITE")) {
+          } else if (str.contains("//SELFIEWRITE") || str.contains("// SELFIEWRITE")) {
             WritableComment.FOREVER
           } else {
             WritableComment.NO_COMMENT

--- a/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotStorage.kt
+++ b/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotStorage.kt
@@ -36,6 +36,8 @@ interface FS {
 interface SnapshotStorage {
   val fs: FS
   val mode: Mode
+  /** Returns true if the sourcecode for the given call has a writable annotation. */
+  fun sourceFileHasWritableComment(call: CallStack): Boolean
   /** Indicates that the following value should be written into test sourcecode. */
   fun writeInline(literalValue: LiteralValue<*>, call: CallStack)
   /** Performs a comparison between disk and actual, writing the actual to disk if necessary. */

--- a/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotStorage.kt
+++ b/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotStorage.kt
@@ -55,5 +55,5 @@ interface SnapshotFileLayout {
   val rootFolder: Path
   val fs: FS
   val allowMultipleEquivalentWritesToOneLocation: Boolean
-  fun sourcecodeForCall(call: CallLocation): Path?
+  fun sourcePathForCall(call: CallLocation): Path?
 }

--- a/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotStorage.kt
+++ b/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotStorage.kt
@@ -41,7 +41,7 @@ interface SnapshotStorage {
   /** Indicates that the following value should be written into test sourcecode. */
   fun writeInline(literalValue: LiteralValue<*>, call: CallStack)
   /** Performs a comparison between disk and actual, writing the actual to disk if necessary. */
-  fun readWriteDisk(actual: Snapshot, sub: String, call: CallStack): ExpectedActual
+  fun readWriteDisk(write: Boolean, actual: Snapshot, sub: String, call: CallStack): ExpectedActual
   /**
    * Marks that the following sub snapshots should be kept, null means to keep all snapshots for the
    * currently executing class.

--- a/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotStorage.kt
+++ b/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotStorage.kt
@@ -15,7 +15,6 @@
  */
 package com.diffplug.selfie.guts
 
-import com.diffplug.selfie.ExpectedActual
 import com.diffplug.selfie.Mode
 import com.diffplug.selfie.Snapshot
 
@@ -40,8 +39,10 @@ interface SnapshotStorage {
   fun sourceFileHasWritableComment(call: CallStack): Boolean
   /** Indicates that the following value should be written into test sourcecode. */
   fun writeInline(literalValue: LiteralValue<*>, call: CallStack)
-  /** Performs a comparison between disk and actual, writing the actual to disk if necessary. */
-  fun readWriteDisk(write: Boolean, actual: Snapshot, sub: String, call: CallStack): ExpectedActual
+  /** Reads the given snapshot from disk. */
+  fun readDisk(sub: String, call: CallStack): Snapshot?
+  /** Writes the given snapshot to disk. */
+  fun writeDisk(actual: Snapshot, sub: String, call: CallStack)
   /**
    * Marks that the following sub snapshots should be kept, null means to keep all snapshots for the
    * currently executing class.

--- a/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SourceFile.kt
+++ b/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SourceFile.kt
@@ -80,6 +80,11 @@ class SourceFile(filename: String, content: String) {
           slice.subSequence(valueStart, slice.length - 1).toString(), language)
     }
   }
+  fun removeSelfieOnceComments() {
+    // TODO: there is a bug here due to string constants, and non-C file comments
+    contentSlice =
+        Slice(contentSlice.toString().replace("//selfieonce", "").replace("// selfieonce", ""))
+  }
   private fun findOnLine(toFind: String, lineOneIndexed: Int): Slice {
     val lineContent = contentSlice.unixLine(lineOneIndexed)
     val idx = lineContent.indexOf(toFind)

--- a/selfie-lib/src/jsMain/kotlin/com/diffplug/selfie/guts/CommentTracker.js.kt
+++ b/selfie-lib/src/jsMain/kotlin/com/diffplug/selfie/guts/CommentTracker.js.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.selfie.guts
+
+internal actual fun <T> createCas(initial: T): CAS<T> = CAS(initial)
+
+internal actual class CAS<T>(var value: T) {
+  actual fun get() = value
+  actual fun updateAndGet(update: (T) -> T): T {
+    value = update(value)
+    return value
+  }
+}

--- a/selfie-lib/src/jsMain/kotlin/com/diffplug/selfie/guts/WriteTracker.js.kt
+++ b/selfie-lib/src/jsMain/kotlin/com/diffplug/selfie/guts/WriteTracker.js.kt
@@ -15,10 +15,11 @@
  */
 package com.diffplug.selfie.guts
 
-actual data class CallLocation(actual val file: String?, actual val line: Int) :
+actual data class CallLocation(actual val fileName: String?, actual val line: Int) :
     Comparable<CallLocation> {
   override fun compareTo(other: CallLocation) =
-      compareValuesBy(this, other, { it.file }, { it.line })
+      compareValuesBy(this, other, { it.fileName }, { it.line })
   actual fun ideLink(layout: SnapshotFileLayout): String = TODO()
+  actual fun samePathAs(other: CallLocation): Boolean = TODO()
 }
 actual fun recordCall(): CallStack = TODO()

--- a/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/guts/CommentTracker.jvm.kt
+++ b/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/guts/CommentTracker.jvm.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.selfie.guts
+
+import java.util.concurrent.atomic.AtomicReference
+
+internal actual fun <T> createCas(initial: T): CAS<T> = CAS(initial)
+
+internal actual class CAS<T>(value: T) {
+  val ref = AtomicReference(value)
+  actual fun get() = ref.get()
+  actual fun updateAndGet(update: (T) -> T): T = ref.updateAndGet(update)
+}

--- a/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/guts/WriteTracker.jvm.kt
+++ b/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/guts/WriteTracker.jvm.kt
@@ -21,21 +21,23 @@ import java.util.stream.Collectors
 actual data class CallLocation(
     val clazz: String,
     val method: String,
-    actual val file: String?,
+    actual val fileName: String?,
     actual val line: Int
 ) : Comparable<CallLocation> {
+  actual fun samePathAs(other: CallLocation): Boolean =
+      clazz == other.clazz && fileName == other.fileName
   override fun compareTo(other: CallLocation): Int =
-      compareValuesBy(this, other, { it.clazz }, { it.method }, { it.file }, { it.line })
+      compareValuesBy(this, other, { it.clazz }, { it.method }, { it.fileName }, { it.line })
 
   /**
    * If the runtime didn't give us the filename, guess it from the class, and try to find the source
    * file by walking the CWD. If we don't find it, report it as a `.class` file.
    */
   private fun findFileIfAbsent(layout: SnapshotFileLayout): String {
-    if (file != null) {
-      return file
+    if (fileName != null) {
+      return fileName
     }
-    return layout.sourcecodeForCall(this)?.let { layout.fs.name(it) }
+    return layout.sourcePathForCall(this)?.let { layout.fs.name(it) }
         ?: "${clazz.substringAfterLast('.')}.class"
   }
 

--- a/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
+++ b/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
@@ -76,6 +76,9 @@ internal object SnapshotStorageJUnit5 : SnapshotStorage {
   @JvmStatic fun initStorage(): SnapshotStorage = this
   override val fs = FSJava
   override val mode = calcMode()
+  override fun sourceFileHasWritableComment(call: CallStack): Boolean {
+    TODO("Not yet implemented")
+  }
 
   private class ClassMethod(val clazz: ClassProgress, val method: String)
   private val threadCtx = ThreadLocal<ClassMethod?>()

--- a/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
+++ b/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
@@ -16,7 +16,6 @@
 package com.diffplug.selfie.junit5
 
 import com.diffplug.selfie.*
-import com.diffplug.selfie.ExpectedActual
 import com.diffplug.selfie.guts.CallStack
 import com.diffplug.selfie.guts.DiskWriteTracker
 import com.diffplug.selfie.guts.FS
@@ -87,20 +86,15 @@ internal object SnapshotStorageJUnit5 : SnapshotStorage {
           ?: throw AssertionError(
               "Selfie `toMatchDisk` must be called only on the original thread.")
   private fun suffix(sub: String) = if (sub == "") "" else "/$sub"
-  override fun readWriteDisk(
-      write: Boolean,
-      actual: Snapshot,
-      sub: String,
-      call: CallStack
-  ): ExpectedActual {
+  override fun readDisk(sub: String, call: CallStack): Snapshot? {
     val cm = classAndMethod()
     val suffix = suffix(sub)
-    return if (write) {
-      cm.clazz.write(cm.method, suffix, actual, call, cm.clazz.parent.layout)
-      ExpectedActual(actual, actual)
-    } else {
-      ExpectedActual(cm.clazz.read(cm.method, suffix), actual)
-    }
+    return cm.clazz.read(cm.method, suffix)
+  }
+  override fun writeDisk(actual: Snapshot, sub: String, call: CallStack) {
+    val cm = classAndMethod()
+    val suffix = suffix(sub)
+    cm.clazz.write(cm.method, suffix, actual, call, cm.clazz.parent.layout)
   }
   override fun keep(subOrKeepAll: String?) {
     val cm = classAndMethod()

--- a/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
+++ b/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
@@ -297,7 +297,6 @@ internal class Progress {
       source.removeSelfieOnceComments()
       layout.fs.fileWrite(path, source.asString)
     }
-
     val written =
         checkForInvalidStale.getAndSet(null)
             ?: throw AssertionError("finishedAllTests() was called more than once.")

--- a/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
+++ b/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
@@ -87,10 +87,15 @@ internal object SnapshotStorageJUnit5 : SnapshotStorage {
           ?: throw AssertionError(
               "Selfie `toMatchDisk` must be called only on the original thread.")
   private fun suffix(sub: String) = if (sub == "") "" else "/$sub"
-  override fun readWriteDisk(actual: Snapshot, sub: String, call: CallStack): ExpectedActual {
+  override fun readWriteDisk(
+      write: Boolean,
+      actual: Snapshot,
+      sub: String,
+      call: CallStack
+  ): ExpectedActual {
     val cm = classAndMethod()
     val suffix = suffix(sub)
-    return if (mode == Mode.overwrite) {
+    return if (write) {
       cm.clazz.write(cm.method, suffix, actual, call, cm.clazz.parent.layout)
       ExpectedActual(actual, actual)
     } else {

--- a/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
+++ b/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
@@ -69,7 +69,7 @@ private fun calcMode(): Mode {
     return Mode.valueOf(override)
   }
   val ci = lowercaseFromEnvOrSys("ci") ?: lowercaseFromEnvOrSys("CI")
-  return if (ci == "true") Mode.readonly else Mode.overwrite
+  return if (ci == "true") Mode.readonly else Mode.interactive
 }
 
 /** Routes between `toMatchDisk()` calls and the snapshot file / pruning machinery. */

--- a/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/DiskBasicTest.kt
+++ b/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/DiskBasicTest.kt
@@ -24,7 +24,7 @@ import org.junitpioneer.jupiter.DisableIfTestFails
 /** Simplest test for verifying read/write of a snapshot. */
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 @DisableIfTestFails
-class ReadWriteTest : Harness("undertest-junit5") {
+class DiskBasicTest : Harness("undertest-junit5") {
   @Test @Order(1)
   fun noSelfie() {
     ut_snapshot().deleteIfExists()

--- a/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/DiskBasicTest.kt
+++ b/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/DiskBasicTest.kt
@@ -81,4 +81,10 @@ class DiskBasicTest : Harness("undertest-junit5") {
         """
                 .trimIndent())
   }
+
+  @Test @Order(6)
+  fun cleanup() {
+    ut_snapshot().deleteIfExists()
+    ut_snapshot().assertDoesNotExist()
+  }
 }

--- a/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/DiskBasicTest.kt
+++ b/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/DiskBasicTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 DiffPlug
+ * Copyright (C) 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/DiskTodoTest.kt
+++ b/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/DiskTodoTest.kt
@@ -25,7 +25,7 @@ import org.junitpioneer.jupiter.DisableIfTestFails
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 @DisableIfTestFails
-class DiskTodo : Harness("undertest-junit5") {
+class DiskTodoTest : Harness("undertest-junit5") {
   companion object {
     var lineNoArg = ""
     var constantArg = ""

--- a/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/Harness.kt
+++ b/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/Harness.kt
@@ -317,4 +317,17 @@ open class Harness(subproject: String) {
       return failure
     }
   }
+  fun gradleInteractivePass() {
+    gradlew("underTest", "-Pselfie=interactive")?.let {
+      throw AssertionError("Expected interactive selfie run to succeed, but it failed.", it)
+    }
+  }
+  fun gradleInteractiveFail(): AssertionFailedError {
+    val failure = gradlew("underTest", "-Pselfie=interactive")
+    if (failure == null) {
+      throw AssertionError("Expected interactive selfie run to fail, but it succeeded.")
+    } else {
+      return failure
+    }
+  }
 }

--- a/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/InteractiveTest.kt
+++ b/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/InteractiveTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.selfie.junit5
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.TestMethodOrder
+import org.junitpioneer.jupiter.DisableIfTestFails
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+@DisableIfTestFails
+class InteractiveTest : Harness("undertest-junit5") {
+  @Test @Order(1)
+  fun initialState() {
+    ut_snapshot().deleteIfExists()
+    ut_snapshot().assertDoesNotExist()
+    ut_mirror().lineWith("expectSelfie(").setContent("    expectSelfie(10).toBe(10)")
+    gradleInteractivePass()
+  }
+
+  @Test @Order(2)
+  fun inlineMismatch() {
+    ut_mirror().lineWith("expectSelfie(").setContent("    expectSelfie(5).toBe(10)")
+    gradleInteractiveFail().message shouldBe "Inline literal did not match the actual value"
+  }
+
+  @Test @Order(3)
+  fun inlineMismatchToBe() {
+    ut_mirror().lineWith("expectSelfie(").setContent("    expectSelfie(5).toBe_TODO(10)")
+    gradleInteractivePass()
+    ut_mirror().lineWith("expectSelfie(").content() shouldBe "    expectSelfie(5).toBe(5)"
+    gradleInteractivePass()
+  }
+
+  @Test @Order(4)
+  fun inlineMismatchForeverComment() {
+    ut_mirror().lineWith("expectSelfie(").setContent("    expectSelfie(5).toBe(10) // SELFIEWRITE")
+    gradleInteractivePass()
+    ut_mirror().lineWith("expectSelfie(").content() shouldBe
+        "    expectSelfie(5).toBe(5) // SELFIEWRITE"
+  }
+
+  @Test @Order(5)
+  fun inlineMismatchOnceComment() {
+    ut_mirror().lineWith("expectSelfie(").setContent("    expectSelfie(5).toBe(10) // selfieonce")
+    gradleInteractivePass()
+    ut_mirror().lineWith("expectSelfie(").content() shouldBe "    expectSelfie(5).toBe(5) "
+  }
+
+  @Test @Order(6)
+  fun diskMismatch() {
+    ut_mirror().lineWith("expectSelfie(").setContent("    expectSelfie(\"5\").toMatchDisk()")
+    gradleInteractiveFail().message shouldBe "No such snapshot"
+  }
+
+  @Test @Order(7)
+  fun diskMismatchToBe() {
+    ut_mirror().lineWith("expectSelfie(").setContent("    expectSelfie(\"5\").toMatchDisk_TODO()")
+    ut_snapshot().deleteIfExists()
+    gradleInteractivePass()
+    ut_mirror().lineWith("expectSelfie(").content() shouldBe "    expectSelfie(\"5\").toMatchDisk()"
+
+    ut_snapshot()
+        .assertContent(
+            """
+            ╔═ example ═╗
+            5
+            ╔═ [end of file] ═╗
+            
+        """
+                .trimIndent())
+    gradleInteractivePass()
+  }
+
+  @Test @Order(8)
+  fun diskMismatchForeverComment() {
+    ut_snapshot().deleteIfExists()
+    ut_mirror()
+        .lineWith("expectSelfie(")
+        .setContent("    expectSelfie(\"5\").toMatchDisk() //SELFIEWRITE")
+    gradleInteractivePass()
+    ut_snapshot()
+        .assertContent(
+            """
+            ╔═ example ═╗
+            5
+            ╔═ [end of file] ═╗
+            
+        """
+                .trimIndent())
+    ut_mirror().lineWith("expectSelfie(").content() shouldBe
+        "    expectSelfie(\"5\").toMatchDisk() //SELFIEWRITE"
+  }
+
+  @Test @Order(9)
+  fun diskMismatchOnceComment() {
+    ut_snapshot().deleteIfExists()
+    ut_mirror()
+        .lineWith("expectSelfie(")
+        .setContent("    expectSelfie(\"5\").toMatchDisk() //selfieonce")
+    gradleInteractivePass()
+    ut_snapshot()
+        .assertContent(
+            """
+            ╔═ example ═╗
+            5
+            ╔═ [end of file] ═╗
+            
+        """
+                .trimIndent())
+    ut_mirror().lineWith("expectSelfie(").content() shouldBe
+        "    expectSelfie(\"5\").toMatchDisk() "
+  }
+
+  @Test @Order(10)
+  fun cleanup() {
+    ut_snapshot().deleteIfExists()
+    ut_mirror().lineWith("expectSelfie(").setContent("    expectSelfie(10).toBe(10)")
+  }
+}

--- a/undertest-junit5/src/test/kotlin/undertest/junit5/UT_DiskBasicTest.kt
+++ b/undertest-junit5/src/test/kotlin/undertest/junit5/UT_DiskBasicTest.kt
@@ -3,7 +3,7 @@ package undertest.junit5
 import com.diffplug.selfie.Selfie.expectSelfie
 import kotlin.test.Test
 
-class UT_ReadWriteTest {
+class UT_DiskBasicTest {
   @Test fun selfie() {
 //    expectSelfie("apple").toMatchDisk()
     expectSelfie("orange").toMatchDisk()

--- a/undertest-junit5/src/test/kotlin/undertest/junit5/UT_DiskTodoTest.kt
+++ b/undertest-junit5/src/test/kotlin/undertest/junit5/UT_DiskTodoTest.kt
@@ -3,7 +3,7 @@ package undertest.junit5
 import com.diffplug.selfie.Selfie.expectSelfie
 import kotlin.test.Test
 
-class UT_DiskTodo {
+class UT_DiskTodoTest {
   @Test fun selfie() {
     expectSelfie("noArg").toMatchDisk_TODO()
     expectSelfie("constantArg").toMatchDisk_TODO("constantArg")

--- a/undertest-junit5/src/test/kotlin/undertest/junit5/UT_InteractiveTest.kt
+++ b/undertest-junit5/src/test/kotlin/undertest/junit5/UT_InteractiveTest.kt
@@ -1,0 +1,11 @@
+package undertest.junit5
+// spotless:off
+import com.diffplug.selfie.Selfie.expectSelfie
+import kotlin.test.Test
+// spotless:on
+
+class UT_InteractiveTest {
+  @Test fun example() {
+    expectSelfie(10).toBe(10)
+  }
+}

--- a/undertest-junit5/src/test/kotlin/undertest/junit5/UT_ReadWriteTest.ss
+++ b/undertest-junit5/src/test/kotlin/undertest/junit5/UT_ReadWriteTest.ss
@@ -1,3 +1,0 @@
-╔═ selfie ═╗
-orange
-╔═ [end of file] ═╗


### PR DESCRIPTION
- implement #74

Still need to do:

- [ ] fix readonly behavior, especially warning on `//selfieonce` and `//SELFIEWRITE` for files without snapshot errors
- [ ] fix error messages to have "how to fix" in the message