### PR TITLE
Add support for Kotlin multiline (and single line) literals

### DIFF
--- a/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/WriteTracker.kt
+++ b/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/WriteTracker.kt
@@ -87,10 +87,17 @@ class InlineWriteTracker : WriteTracker<CallLocation, LiteralValue<*>>() {
     if (literalValue.expected != null) {
       // if expected == null, it's a `toBe_TODO()`, so there's nothing to check
       val content = SourceFile(layout.fs.name(file), layout.fs.fileRead(file))
-      val parsedValue = content.parseToBe(call.location.line).parseLiteral(literalValue.format)
+      val parsedValue =
+          try {
+            content.parseToBe(call.location.line).parseLiteral(literalValue.format)
+          } catch (e: Exception) {
+            throw AssertionError(
+                "Error while parsing the literal at ${call.location.ideLink(layout)}. Please report this error at https://github.com/diffplug/selfie",
+                e)
+          }
       if (parsedValue != literalValue.expected) {
         throw layout.fs.assertFailed(
-            "There is likely a bug in Selfie's literal parsing.",
+            "Selfie cannot modify the literal at ${call.location.ideLink(layout)} because Selfie has a parsing bug. Please report this error at https://github.com/diffplug/selfie",
             literalValue.expected,
             parsedValue)
       }

--- a/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/KotlinMultilineString.kt
+++ b/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/KotlinMultilineString.kt
@@ -19,19 +19,19 @@ import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 
 class KotlinMultilineString {
-    @Test
-    fun newlines() {
-        """first
+  @Test
+  fun newlines() {
+    """first
 """ shouldBe "first\n"
-        """
+    """
 second""" shouldBe "\nsecond"
-    }
+  }
 
-    @Test
-    fun indentation() {
-        """
+  @Test
+  fun indentation() {
+    """
 """ shouldBe "\n"
-        """
+    """
   """ shouldBe "\n  "
-    }
+  }
 }

--- a/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/KotlinMultilineString.kt
+++ b/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/KotlinMultilineString.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.selfie.guts
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class KotlinMultilineString {
+    @Test
+    fun newlines() {
+        """first
+""" shouldBe "first\n"
+        """
+second""" shouldBe "\nsecond"
+    }
+
+    @Test
+    fun indentation() {
+        """
+""" shouldBe "\n"
+        """
+  """ shouldBe "\n  "
+    }
+}

--- a/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/LiteralStringTest.kt
+++ b/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/LiteralStringTest.kt
@@ -31,6 +31,18 @@ class LiteralStringTest {
   }
 
   @Test
+  fun singleLineKotlinToSource() {
+    singleLineKotlinToSource("1", "`1`")
+    singleLineKotlinToSource("\\", "`\\\\`")
+    singleLineKotlinToSource("$", "`s{'s'}`".replace('s', '$'))
+    singleLineKotlinToSource("1\n\tABC", "`1\\n\\tABC`")
+  }
+  private fun singleLineKotlinToSource(value: String, expected: String) {
+    val actual = LiteralString.singleLineKotlinGroovyToSource(value)
+    actual shouldBe expected.replace("`", "\"")
+  }
+
+  @Test
   fun multiLineJavaToSource() {
     multiLineJavaToSource("1", "'''\n1'''")
     multiLineJavaToSource("\\", "'''\n\\\\'''")
@@ -62,6 +74,18 @@ class LiteralStringTest {
   }
   private fun multiLineJavaFromSource(value: String, expected: String) {
     val actual = LiteralString.multiLineJavaFromSource("\"\"\"${value.replace("'", "\"")}\"\"\"")
+    actual shouldBe expected
+  }
+
+  @Test
+  fun singleLineKotlinFromSource() {
+    singleLineKotlinFromSource("1", "1")
+    singleLineKotlinFromSource("\\\\", "\\")
+    singleLineKotlinFromSource("s{'s'}".replace('s', '$'), "$")
+    singleLineKotlinFromSource("1\\n\\tABC", "1\n\tABC")
+  }
+  private fun singleLineKotlinFromSource(value: String, expected: String) {
+    val actual = LiteralString.singleLineKotlinGroovyFromSource("\"${value}\"")
     actual shouldBe expected
   }
 }

--- a/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/LiteralStringTest.kt
+++ b/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/LiteralStringTest.kt
@@ -52,6 +52,17 @@ class LiteralStringTest {
     val actual = LiteralString.multiLineJavaToSource(value)
     actual shouldBe expected.replace("'", "\"")
   }
+  private val KOTLIN_DOLLAR = "s{'s'}".replace('s', '$')
+
+  @Test
+  fun multiLineKotlinToSource() {
+    multiLineKotlinToSource("1", "```1```")
+    multiLineKotlinToSource("$", "```$KOTLIN_DOLLAR```")
+  }
+  private fun multiLineKotlinToSource(value: String, expected: String) {
+    val actual = LiteralString.multiLineKotlinToSource(value)
+    actual shouldBe expected.replace("`", "\"")
+  }
 
   @Test
   fun singleLineJavaFromSource() {

--- a/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/LiteralStringTest.kt
+++ b/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/LiteralStringTest.kt
@@ -20,83 +20,83 @@ import kotlin.test.Test
 
 class LiteralStringTest {
   @Test
-  fun singleLineJavaToSource() {
-    singleLineJavaToSource("1", "'1'")
-    singleLineJavaToSource("\\", "'\\\\'")
-    singleLineJavaToSource("1\n\tABC", "'1\\n\\tABC'")
+  fun encodeSingleJava() {
+    encodeSingleJava("1", "'1'")
+    encodeSingleJava("\\", "'\\\\'")
+    encodeSingleJava("1\n\tABC", "'1\\n\\tABC'")
   }
-  private fun singleLineJavaToSource(value: String, expected: String) {
-    val actual = LiteralString.singleLineJavaToSource(value)
+  private fun encodeSingleJava(value: String, expected: String) {
+    val actual = LiteralString.encodeSingleJava(value)
     actual shouldBe expected.replace("'", "\"")
   }
 
   @Test
-  fun singleLineKotlinToSource() {
-    singleLineKotlinToSource("1", "`1`")
-    singleLineKotlinToSource("\\", "`\\\\`")
-    singleLineKotlinToSource("$", "`s{'s'}`".replace('s', '$'))
-    singleLineKotlinToSource("1\n\tABC", "`1\\n\\tABC`")
+  fun encodeSingleJavaWithDollars() {
+    encodeSingleJavaWithDollars("1", "`1`")
+    encodeSingleJavaWithDollars("\\", "`\\\\`")
+    encodeSingleJavaWithDollars("$", "`s{'s'}`".replace('s', '$'))
+    encodeSingleJavaWithDollars("1\n\tABC", "`1\\n\\tABC`")
   }
-  private fun singleLineKotlinToSource(value: String, expected: String) {
-    val actual = LiteralString.singleLineKotlinGroovyToSource(value)
+  private fun encodeSingleJavaWithDollars(value: String, expected: String) {
+    val actual = LiteralString.encodeSingleJavaWithDollars(value)
     actual shouldBe expected.replace("`", "\"")
   }
 
   @Test
-  fun multiLineJavaToSource() {
-    multiLineJavaToSource("1", "'''\n1'''")
-    multiLineJavaToSource("\\", "'''\n\\\\'''")
-    multiLineJavaToSource("  leading\ntrailing  ", "'''\n" + "\\s leading\n" + "trailing \\s'''")
+  fun encodeMultiJava() {
+    encodeMultiJava("1", "'''\n1'''")
+    encodeMultiJava("\\", "'''\n\\\\'''")
+    encodeMultiJava("  leading\ntrailing  ", "'''\n" + "\\s leading\n" + "trailing \\s'''")
   }
-  private fun multiLineJavaToSource(value: String, expected: String) {
-    val actual = LiteralString.multiLineJavaToSource(value)
+  private fun encodeMultiJava(value: String, expected: String) {
+    val actual = LiteralString.encodeMultiJava(value)
     actual shouldBe expected.replace("'", "\"")
   }
   private val KOTLIN_DOLLAR = "s{'s'}".replace('s', '$')
 
   @Test
-  fun multiLineKotlinToSource() {
-    multiLineKotlinToSource("1", "```1```")
-    multiLineKotlinToSource("$", "```$KOTLIN_DOLLAR```")
+  fun encodeMultiKotlin() {
+    encodeMultiKotlin("1", "```1```")
+    encodeMultiKotlin("$", "```$KOTLIN_DOLLAR```")
   }
-  private fun multiLineKotlinToSource(value: String, expected: String) {
-    val actual = LiteralString.multiLineKotlinToSource(value)
+  private fun encodeMultiKotlin(value: String, expected: String) {
+    val actual = LiteralString.encodeMultiKotlin(value)
     actual shouldBe expected.replace("`", "\"")
   }
 
   @Test
-  fun singleLineJavaFromSource() {
-    singleLineJavaFromSource("1", "1")
-    singleLineJavaFromSource("\\\\", "\\")
-    singleLineJavaFromSource("1\\n\\tABC", "1\n\tABC")
+  fun parseSingleJava() {
+    parseSingleJava("1", "1")
+    parseSingleJava("\\\\", "\\")
+    parseSingleJava("1\\n\\tABC", "1\n\tABC")
   }
-  private fun singleLineJavaFromSource(value: String, expected: String) {
-    val actual = LiteralString.singleLineJavaFromSource("\"${value.replace("'", "\"")}\"")
+  private fun parseSingleJava(value: String, expected: String) {
+    val actual = LiteralString.parseSingleJava("\"${value.replace("'", "\"")}\"")
     actual shouldBe expected
   }
 
   @Test
-  fun multiLineJavaFromSource() {
-    multiLineJavaFromSource("\n123\nabc", "123\nabc")
-    multiLineJavaFromSource("\n  123\n  abc", "123\nabc")
-    multiLineJavaFromSource("\n  123  \n  abc\t", "123\nabc")
-    multiLineJavaFromSource("\n  123  \n  abc\t", "123\nabc")
-    multiLineJavaFromSource("\n  123  \\s\n  abc\t\\s", "123   \nabc\t ")
+  fun parseMultiJava() {
+    parseMultiJava("\n123\nabc", "123\nabc")
+    parseMultiJava("\n  123\n  abc", "123\nabc")
+    parseMultiJava("\n  123  \n  abc\t", "123\nabc")
+    parseMultiJava("\n  123  \n  abc\t", "123\nabc")
+    parseMultiJava("\n  123  \\s\n  abc\t\\s", "123   \nabc\t ")
   }
-  private fun multiLineJavaFromSource(value: String, expected: String) {
-    val actual = LiteralString.multiLineJavaFromSource("\"\"\"${value.replace("'", "\"")}\"\"\"")
+  private fun parseMultiJava(value: String, expected: String) {
+    val actual = LiteralString.parseMultiJava("\"\"\"${value.replace("'", "\"")}\"\"\"")
     actual shouldBe expected
   }
 
   @Test
-  fun singleLineKotlinFromSource() {
-    singleLineKotlinFromSource("1", "1")
-    singleLineKotlinFromSource("\\\\", "\\")
-    singleLineKotlinFromSource("s{'s'}".replace('s', '$'), "$")
-    singleLineKotlinFromSource("1\\n\\tABC", "1\n\tABC")
+  fun parseSingleJavaWithDollars() {
+    parseSingleJavaWithDollars("1", "1")
+    parseSingleJavaWithDollars("\\\\", "\\")
+    parseSingleJavaWithDollars("s{'s'}".replace('s', '$'), "$")
+    parseSingleJavaWithDollars("1\\n\\tABC", "1\n\tABC")
   }
-  private fun singleLineKotlinFromSource(value: String, expected: String) {
-    val actual = LiteralString.singleLineKotlinGroovyFromSource("\"${value}\"")
+  private fun parseSingleJavaWithDollars(value: String, expected: String) {
+    val actual = LiteralString.parseSingleJavaWithDollars("\"${value}\"")
     actual shouldBe expected
   }
 }

--- a/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/StringLiteralsKotlinTest.kt
+++ b/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/StringLiteralsKotlinTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.selfie.junit5
+
+import kotlin.test.Test
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.TestMethodOrder
+import org.junitpioneer.jupiter.DisableIfTestFails
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+@DisableIfTestFails
+class StringLiteralsKotlinTest : Harness("undertest-junit5") {
+  @Test @Order(1)
+  fun readFailsBecauseTodo() {
+    gradleReadSSFail()
+  }
+
+  @Test @Order(2)
+  fun writeSucceeds() {
+    gradleWriteSS()
+  }
+
+  @Test @Order(3)
+  fun nowReadSucceeds() {
+    gradleReadSS()
+  }
+
+  @Test @Order(4)
+  fun cleanup() {
+    ut_mirrorJava().restoreFromGit()
+  }
+}

--- a/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/StringLiteralsKotlinTest.kt
+++ b/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/StringLiteralsKotlinTest.kt
@@ -41,6 +41,6 @@ class StringLiteralsKotlinTest : Harness("undertest-junit5") {
 
   @Test @Order(4)
   fun cleanup() {
-    ut_mirrorJava().restoreFromGit()
+    ut_mirror().restoreFromGit()
   }
 }

--- a/undertest-junit5/src/test/java/undertest/junit5/UT_StringLiteralsJavaTest.java
+++ b/undertest-junit5/src/test/java/undertest/junit5/UT_StringLiteralsJavaTest.java
@@ -6,30 +6,51 @@ import static com.diffplug.selfie.Selfie.expectSelfie;
 public class UT_StringLiteralsJavaTest {
     @Test
     public void empty() {
-        expectSelfie("").toBe_TODO();
+        expectSelfie("").toBe("");
     }
 
     @Test
     public void tabs() {
-        expectSelfie("\t\t\t").toBe_TODO();
+        expectSelfie("\t\t\t").toBe("\t\t\t");
     }
 
     @Test
     public void spaces() {
-        expectSelfie("   ").toBe_TODO();
+        expectSelfie("   ").toBe("   ");
     }
 
     @Test
     public void newlines() {
-        expectSelfie("\n").toBe_TODO();
-        expectSelfie("\n\n").toBe_TODO();
-        expectSelfie("\n\n\n").toBe_TODO();
+        expectSelfie("\n").toBe("""
+
+""");
+        expectSelfie("\n\n").toBe("""
+
+
+""");
+        expectSelfie("\n\n\n").toBe("""
+
+
+
+""");
+    }
+
+    @Test
+    public void escapableCharacters() {
+        expectSelfie(" ' \" $ ").toBe(" ' \" $ ");
+        expectSelfie(" ' \" $ \n \"\"\"\"\"\"\"\"\"\t").toBe("""
+\s' " $\s
+\s\"\"\"\"\"\"\"\"\"\t""");
     }
 
     @Test
     public void allOfIt() {
         expectSelfie("  a\n" +
                 "a  \n" +
-                "\t a \t\n").toBe_TODO();
+                "\t a \t\n").toBe("""
+\s a
+a \s
+\t a \t
+""");
     }
 }

--- a/undertest-junit5/src/test/java/undertest/junit5/UT_StringLiteralsJavaTest.java
+++ b/undertest-junit5/src/test/java/undertest/junit5/UT_StringLiteralsJavaTest.java
@@ -6,51 +6,36 @@ import static com.diffplug.selfie.Selfie.expectSelfie;
 public class UT_StringLiteralsJavaTest {
     @Test
     public void empty() {
-        expectSelfie("").toBe("");
+        expectSelfie("").toBe_TODO();
     }
 
     @Test
     public void tabs() {
-        expectSelfie("\t\t\t").toBe("\t\t\t");
+        expectSelfie("\t\t\t").toBe_TODO();
     }
 
     @Test
     public void spaces() {
-        expectSelfie("   ").toBe("   ");
+        expectSelfie("   ").toBe_TODO();
     }
 
     @Test
     public void newlines() {
-        expectSelfie("\n").toBe("""
-
-""");
-        expectSelfie("\n\n").toBe("""
-
-
-""");
-        expectSelfie("\n\n\n").toBe("""
-
-
-
-""");
+        expectSelfie("\n").toBe_TODO();
+        expectSelfie("\n\n").toBe_TODO();
+        expectSelfie("\n\n\n").toBe_TODO();
     }
 
     @Test
     public void escapableCharacters() {
-        expectSelfie(" ' \" $ ").toBe(" ' \" $ ");
-        expectSelfie(" ' \" $ \n \"\"\"\"\"\"\"\"\"\t").toBe("""
-\s' " $\s
-\s\"\"\"\"\"\"\"\"\"\t""");
+        expectSelfie(" ' \" $ ").toBe_TODO();
+        expectSelfie(" ' \" $ \n \"\"\"\"\"\"\"\"\"\t").toBe_TODO();
     }
 
     @Test
     public void allOfIt() {
         expectSelfie("  a\n" +
                 "a  \n" +
-                "\t a \t\n").toBe("""
-\s a
-a \s
-\t a \t
-""");
+                "\t a \t\n").toBe_TODO();
     }
 }

--- a/undertest-junit5/src/test/kotlin/undertest/junit5/UT_StringLiteralsKotlinTest.kt
+++ b/undertest-junit5/src/test/kotlin/undertest/junit5/UT_StringLiteralsKotlinTest.kt
@@ -1,0 +1,33 @@
+package undertest.junit5
+
+import com.diffplug.selfie.Selfie.expectSelfie
+import org.junit.jupiter.api.Test
+
+class UT_StringLiteralsKotlinTest {
+  @Test fun empty() {
+    expectSelfie("").toBe_TODO()
+  }
+
+  @Test fun tabs() {
+    expectSelfie("\t\t\t").toBe_TODO()
+  }
+
+  @Test fun spaces() {
+    expectSelfie("   ").toBe_TODO()
+  }
+
+  @Test fun newlines() {
+    expectSelfie("\n").toBe_TODO()
+    expectSelfie("\n\n").toBe_TODO()
+    expectSelfie("\n\n\n").toBe_TODO()
+  }
+
+  @Test fun escapableCharacters() {
+    expectSelfie(" ' \" $ ").toBe_TODO()
+    expectSelfie(" ' \" $ \n \"\"\"\"\"\"\"\"\"\t").toBe_TODO()
+  }
+
+  @Test fun allOfIt() {
+    expectSelfie("  a\n" + "a  \n" + "\t a \t\n").toBe_TODO()
+  }
+}


### PR DESCRIPTION
Kotlin's $ escaping made this a bit tricky. Groovy is very similar but a teensy bit different, we should update that.