### PR TITLE
Fine tune styles

### DIFF
--- a/docs/src/components/HeadingPopout.tsx
+++ b/docs/src/components/HeadingPopout.tsx
@@ -19,10 +19,14 @@ export function HeadingPopout({
   return (
     <Button
       className={clsx([
-        "text-white",
-        "bg-blue",
+        "bg-white",
+        "fill:black",
+        "hover:bg-blue",
+        "hover:fill-white",
+        "shadow-button",
+        "tablet:shadow-button-tablet",
         "w-[70px]",
-        "rounded-[4px]",
+        "rounded-[10px]",
         "h-[30px]",
         "z-20",
         "relative",
@@ -31,7 +35,7 @@ export function HeadingPopout({
       ])}
       onClick={handleClick}
     >
-      <Popout width={36} height={36} />
+      <Popout />
     </Button>
   );
 }

--- a/docs/src/components/Icons/Popout.tsx
+++ b/docs/src/components/Icons/Popout.tsx
@@ -1,8 +1,20 @@
+import clsx from "clsx";
 import { SVGProps } from "react";
 
 export function Popout(props: SVGProps<SVGSVGElement>) {
   return (
-    <svg fill="#FFF" viewBox="0 0 32 32" {...props}>
+    <svg
+      className={clsx([
+        "w-[26px]",
+        "h-[26px]",
+        "tablet:w-[32px]",
+        "tablet:h-[32px]",
+        "desktop:w-[36px]",
+        "desktop:h-[36px]",
+      ])}
+      viewBox="0 0 32 32"
+      {...props}
+    >
       <path d="M15.694 13.541l2.666 2.665 5.016-5.017 2.59 2.59 0.004-7.734-7.785-0.046 2.526 2.525-5.017 5.017zM25.926 16.945l-1.92-1.947 0.035 9.007-16.015 0.009 0.016-15.973 8.958-0.040-2-2h-7c-1.104 0-2 0.896-2 2v16c0 1.104 0.896 2 2 2h16c1.104 0 2-0.896 2-2l-0.074-7.056z" />
     </svg>
   );

--- a/docs/src/components/Navigation/SubNavigation.tsx
+++ b/docs/src/components/Navigation/SubNavigation.tsx
@@ -104,7 +104,7 @@ const sharedClasses = clsx([
   "justify-center",
   "items-center",
   "cursor-pointer",
-  "text-[16px]",
+  "text-[8px]",
   "border",
   "h-[23px]",
   "border-black",

--- a/docs/src/components/mdx.tsx
+++ b/docs/src/components/mdx.tsx
@@ -43,6 +43,7 @@ export function code({ children, ...props }: ParentComponentProps) {
         "rounded",
         "text-sm",
         "leading-[1.5em]",
+        "break-words",
       ]);
   return children ? (
     <code
@@ -105,7 +106,10 @@ export function h3({ children, ...props }: ParentComponentProps) {
 
 export function a({ children, ...props }: ParentComponentProps) {
   return (
-    <a {...props} className="underline hover:text-blue visited:hover:text-purple">
+    <a
+      {...props}
+      className="underline hover:text-blue visited:hover:text-purple"
+    >
       {children}
     </a>
   );


### PR DESCRIPTION
- Popout styles should look like other unpressed buttons
- Shrink heading font size at mobile screen widths to fit
- Let long inline `<code>` elements reflow to new lines