### PR TITLE
Fix landing page CTA bug

### DIFF
--- a/docs/src/components/FooterCTA/FooterCTA.tsx
+++ b/docs/src/components/FooterCTA/FooterCTA.tsx
@@ -9,11 +9,14 @@ export function FooterCTA() {
   const imageRef = useRef<HTMLImageElement | null>(null);
   const [imageHeight, setImageHeight] = useState(0);
 
-  function handleResize() {
+  function setImageHeightFromRef() {
     setImageHeight(imageRef.current!.height);
   }
 
   function handleScroll() {
+    if (!imageHeight) {
+      setImageHeightFromRef();
+    }
     if (!footerRef.current || !spacerRef.current) return;
     // 0 at the current scroll position, 1 at the bottom of the page
     const topOfHorseFromBottomOfScreen =
@@ -36,10 +39,10 @@ export function FooterCTA() {
 
   useEffect(() => {
     window.addEventListener("scroll", handleScroll, false);
-    window.addEventListener("resize", handleResize, false);
+    window.addEventListener("resize", setImageHeightFromRef, false);
     return () => {
       window.removeEventListener("scroll", handleScroll);
-      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("resize", setImageHeightFromRef);
     };
   }, [imageHeight]);
 


### PR DESCRIPTION
#100 

Issue can be reproduced more simply by:

1. "Hard" navigating to any route other than the landing page (either type in the URL or press the browser refresh button)
2. "Soft" navigating to the landing page by using the "why" link in the app itself (Next.js client-side navigation)
3. Scrolling down

The "resize" event isn't being called after a client-side navigation event. Solution is to make sure the `imageHeight` is set in the scroll event handler.