### PR TITLE
Smuggle errors from `TestExecutionListener`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- We already [smuggle errors from initialization](https://github.com/diffplug/selfie/pull/94) to help debug them, and now we also smuggle errors that happen during test execution. ([#117](https://github.com/diffplug/selfie/pull/117))
 
 ## [1.0.1] - 2024-01-19
 ### Fixed

--- a/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
+++ b/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
@@ -319,22 +319,34 @@ internal class Progress {
 class SelfieTestExecutionListener : TestExecutionListener {
   private val progress = Progress()
   override fun executionStarted(testIdentifier: TestIdentifier) {
-    if (isRoot(testIdentifier)) return
-    val (clazz, method) = parseClassMethod(testIdentifier)
-    progress.start(clazz, method)
+    try {
+      if (isRoot(testIdentifier)) return
+      val (clazz, method) = parseClassMethod(testIdentifier)
+      progress.start(clazz, method)
+    } catch (e: Throwable) {
+      progress.layout.smuggledError = e
+    }
   }
   override fun executionSkipped(testIdentifier: TestIdentifier, reason: String) {
-    val (clazz, method) = parseClassMethod(testIdentifier)
-    progress.skip(clazz, method)
+    try {
+      val (clazz, method) = parseClassMethod(testIdentifier)
+      progress.skip(clazz, method)
+    } catch (e: Throwable) {
+      progress.layout.smuggledError = e
+    }
   }
   override fun executionFinished(
       testIdentifier: TestIdentifier,
       testExecutionResult: TestExecutionResult
   ) {
-    if (isRoot(testIdentifier)) return
-    val (clazz, method) = parseClassMethod(testIdentifier)
-    progress.finishWithSuccess(
-        clazz, method, testExecutionResult.status == TestExecutionResult.Status.SUCCESSFUL)
+    try {
+      if (isRoot(testIdentifier)) return
+      val (clazz, method) = parseClassMethod(testIdentifier)
+      progress.finishWithSuccess(
+          clazz, method, testExecutionResult.status == TestExecutionResult.Status.SUCCESSFUL)
+    } catch (e: Throwable) {
+      progress.layout.smuggledError = e
+    }
   }
   override fun testPlanExecutionFinished(testPlan: TestPlan?) {
     progress.finishedAllTests()

--- a/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotFileLayoutJUnit5.kt
+++ b/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotFileLayoutJUnit5.kt
@@ -22,7 +22,7 @@ import com.diffplug.selfie.guts.SnapshotFileLayout
 
 class SnapshotFileLayoutJUnit5(settings: SelfieSettingsAPI, override val fs: FS) :
     SnapshotFileLayout {
-  private val smuggledError: Throwable? =
+  internal var smuggledError: Throwable? =
       if (settings is SelfieSettingsSmuggleError) settings.error else null
   override val rootFolder = settings.rootFolder
   private val otherSourceRoots = settings.otherSourceRoots
@@ -33,9 +33,7 @@ class SnapshotFileLayoutJUnit5(settings: SelfieSettingsAPI, override val fs: FS)
   val extension: String = ".ss"
   private val cache = ThreadLocal<Pair<CallLocation, Path>?>()
   override fun sourcePathForCall(call: CallLocation): Path {
-    if (smuggledError != null) {
-      throw smuggledError
-    }
+    smuggledError?.let { throw it }
     val nonNull =
         sourcePathForCallMaybe(call)
             ?: throw fs.assertFailed(


### PR DESCRIPTION
- We started smuggling errors from initialization in #94
- Now we smuggle errors from `TestExecutionListener` too