### PR TITLE
Add a route to selfie.dev for the gif demo.

### DIFF
--- a/jvm/example-junit5/src/test/java/com/example/DemoGif.java
+++ b/jvm/example-junit5/src/test/java/com/example/DemoGif.java
@@ -1,0 +1,15 @@
+package com.example;
+
+import static selfie.SelfieSettings.expectSelfie;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+public class DemoGif {
+  @Test
+  void homepage() {
+    // see .github/demo.gif
+    RestAssured.given();
+    expectSelfie(RestAssured.get("/"));
+  }
+}

--- a/jvm/example-junit5/src/test/java/selfie/SelfieSettings.java
+++ b/jvm/example-junit5/src/test/java/selfie/SelfieSettings.java
@@ -10,6 +10,7 @@ import com.example.EmailDev;
 import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter;
 import io.jooby.StatusCode;
 import io.restassured.response.Response;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -84,14 +85,17 @@ public class SelfieSettings extends SelfieSettingsAPI {
 
   // need 'com.vladsch.flexmark:flexmark-html2md-converter:0.64.8' on the test claspath
   private static String htmlToMd(String html) {
+    var cleanHtml = html.replaceAll("<br.*?>", "");
     var md =
         new FlexmarkHtmlConverter.Builder()
             .build()
-            .convert(html)
+            .convert(cleanHtml)
             .replaceAll("(?m)^====+", "")
             .replaceAll("(?m)^\\-\\-\\-+", "")
             .replaceAll("(?m)^\\*\\*\\*[\\* ]+", "")
             .replaceAll("\n\n+", "\n\n");
-    return md.trim();
+    var trimLines =
+        Arrays.stream(md.split("\n")).map(String::trim).collect(Collectors.joining("\n"));
+    return trimLines;
   }
 }

--- a/selfie.dev/public/robots.txt
+++ b/selfie.dev/public/robots.txt
@@ -1,0 +1,4 @@
+Sitemap: https://selfie.dev/sitemap.xml
+
+User-agent: *
+Disallow: /gif-demo

--- a/selfie.dev/src/components/HeroGifDemo.tsx
+++ b/selfie.dev/src/components/HeroGifDemo.tsx
@@ -1,37 +1,11 @@
 import clsx from "clsx";
-import { ButtonList } from "./ButtonList";
-import { IntroText } from "./IntroText";
 import { Logo } from "./Logo";
 import { Mascot } from "./Mascot";
-
-const sharedClasses = clsx([
-  "w-[34px]",
-  "h-[23px]",
-  "rounded-[4px]",
-  "text-[12px]",
-  "wide-phone:w-[44px]",
-  "tablet:w-[73px]",
-  "desktop:w-[110px]",
-  "hover:text-white",
-  "hover:bg-blue",
-]);
-
-const pressedClasses = clsx([
-  "mt-[1px]",
-  "text-white",
-  "bg-blue",
-  "shadow-none",
-  "tablet:mt-[3px]",
-  sharedClasses,
-]);
-
-const unPressedClasses = clsx([
-  "text-black",
-  "bg-white",
-  "shadow-button",
-  "tablet:shadow-button-tablet",
-  sharedClasses,
-]);
+import slugify from "@sindresorhus/slugify";
+import { Button } from "./Button";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { getPathParts } from "@/lib/languageFromPath";
 
 export function HeroGifDemo() {
   return (
@@ -85,5 +59,200 @@ export function HeroGifDemo() {
       </div>
       <IntroText />
     </div>
+  );
+}
+
+
+export function ButtonList() {
+  const router = useRouter();
+  const selectedLanguage = getPathParts(router.pathname).language;
+  return (
+    <div
+      className={clsx([
+        "align-center",
+        "flex",
+        "flex-row",
+        "justify-between",
+        "wide-phone:w-[220px]",
+        "tablet:w-[328px]",
+        "desktop:w-[490px]",
+      ])}
+    >
+      <Link href="/jvm">
+        <Button
+          className={
+            ["jvm", ""].includes(selectedLanguage)
+              ? pressedClasses
+              : unPressedClasses
+          }
+        >
+          jvm
+        </Button>
+      </Link>
+      <Link href="/js">
+        <Button
+          className={
+            selectedLanguage === "js" ? pressedClasses : unPressedClasses
+          }
+        >
+          js
+        </Button>
+      </Link>
+      <Link href="/other-platforms">
+        <Button
+          className={
+            selectedLanguage === "py" ? pressedClasses : unPressedClasses
+          }
+        >
+          py
+        </Button>
+      </Link>
+      <Link href="/other-platforms">
+        <Button
+          className={
+            selectedLanguage === "other-platforms"
+              ? pressedClasses
+              : unPressedClasses
+          }
+        >
+          ...
+        </Button>
+      </Link>
+    </div>
+  );
+}
+
+const sharedClasses = clsx([
+  "w-[34px]",
+  "h-[23px]",
+  "rounded-[4px]",
+  "text-[12px]",
+  "wide-phone:w-[44px]",
+  "tablet:w-[73px]",
+  "desktop:w-[110px]",
+  "hover:text-white",
+  "hover:bg-blue",
+]);
+
+const pressedClasses = clsx([
+  "mt-[1px]",
+  "text-white",
+  "bg-blue",
+  "shadow-none",
+  "tablet:mt-[3px]",
+  sharedClasses,
+]);
+
+const unPressedClasses = clsx([
+  "text-black",
+  "bg-white",
+  "shadow-button",
+  "tablet:shadow-button-tablet",
+  sharedClasses,
+]);
+
+const THE_CONTEXT_WINDOW = "https://thecontextwindow.ai/p/temporarily-embarrassed-snapshots";
+
+export function IntroText() {
+  return (
+    <div
+      className={clsx([
+        "w-full",
+        "flex",
+        "flex-col",
+        "absolute",
+        "top-[529px]",
+        "gap-[30px]",
+        "wide-phone:top-[184px]",
+        "wide-phone:items-end",
+        "wide-phone:text-right",
+        "tablet:top-[262px]",
+        "tablet:gap-[40px]",
+        "desktop:top-[345px]",
+      ])}
+    >
+      <p
+        className={clsx([
+          "text-[20px]",
+          "leading-[1.25em]",
+          "tablet:text-[30px]",
+          "desktop:text-[45px]",
+        ])}
+      >
+        Which is <br className="tablet:hidden" />{" "}
+        <SectionLink title="literal" />, <SectionLink title="lensable" />
+        <br /> and <SectionLink title="like a filesystem" />
+      </p>
+      <Link href="/jvm/get-started">
+        <Button
+          className={clsx([
+            "w-[154px]",
+            "h-[35px]",
+            "rounded-[10px]",
+            "text-[22px]",
+            "tablet:w-[154px]",
+            "desktop:w-[232px]",
+            "text-black",
+            "bg-white",
+            "shadow-button",
+            "tablet:shadow-button-tablet",
+            "hover:text-white",
+            "hover:bg-blue",
+          ])}
+        >
+          get started
+        </Button>
+      </Link>
+      <div
+        className={clsx([
+          "text-[18px]",
+          "leading-[1.2em]",
+          "grid",
+          "gap-[30px]",
+          "tablet:text-[22px]",
+          "desktop:text-[34px]",
+        ])}
+      >
+        <p>
+          Snapshot testing is the <br />{" "}
+          <a href={THE_CONTEXT_WINDOW} className="text-blue hover:underline cursor-pointer">fastest and most precise</a>
+          <br />
+          mechanism to{" "}
+          <a href={THE_CONTEXT_WINDOW} className="text-red hover:underline cursor-pointer">
+            record <br /> and specify
+          </a>{" "}
+          the <br />
+          <a href={THE_CONTEXT_WINDOW} className="text-green hover:underline cursor-pointer">
+            behavior of your <br />
+            system and its <br />
+            components
+          </a>
+          .
+        </p>
+        <p>
+          Robots are <br /> writing their <br />
+          own code. Are
+          <br /> you still writing
+          <br />
+          assertions by <br />
+          hand?
+        </p>
+      </div>
+    </div>
+  );
+}
+
+type SectionLinkProps = {
+  title: string;
+};
+function SectionLink({ title }: SectionLinkProps) {
+  return (
+    <Link
+      href={`#${slugify(title)}`}
+      scroll={false}
+      className="cursor-pointer underline hover:text-blue"
+    >
+      {title}
+    </Link>
   );
 }

--- a/selfie.dev/src/components/HeroGifDemo.tsx
+++ b/selfie.dev/src/components/HeroGifDemo.tsx
@@ -80,21 +80,21 @@ export function ButtonList() {
         >
           jvm
         </Button>
-      </Link>
+      </Link>{" "}
       <Link href="/js">
         <Button
           className={unPressedClasses}
         >
           js
         </Button>
-      </Link>
+      </Link>{" "}
       <Link href="/other-platforms">
         <Button
           className={unPressedClasses}
         >
           py
         </Button>
-      </Link>
+      </Link>{" "}
       <Link href="/other-platforms">
         <Button
           className={unPressedClasses}

--- a/selfie.dev/src/components/HeroGifDemo.tsx
+++ b/selfie.dev/src/components/HeroGifDemo.tsx
@@ -4,8 +4,6 @@ import { Mascot } from "./Mascot";
 import slugify from "@sindresorhus/slugify";
 import { Button } from "./Button";
 import Link from "next/link";
-import { useRouter } from "next/router";
-import { getPathParts } from "@/lib/languageFromPath";
 
 export function HeroGifDemo() {
   return (
@@ -64,8 +62,6 @@ export function HeroGifDemo() {
 
 
 export function ButtonList() {
-  const router = useRouter();
-  const selectedLanguage = getPathParts(router.pathname).language;
   return (
     <div
       className={clsx([
@@ -80,40 +76,28 @@ export function ButtonList() {
     >
       <Link href="/jvm">
         <Button
-          className={
-            ["jvm", ""].includes(selectedLanguage)
-              ? pressedClasses
-              : unPressedClasses
-          }
+          className={unPressedClasses}
         >
           jvm
         </Button>
       </Link>
       <Link href="/js">
         <Button
-          className={
-            selectedLanguage === "js" ? pressedClasses : unPressedClasses
-          }
+          className={unPressedClasses}
         >
           js
         </Button>
       </Link>
       <Link href="/other-platforms">
         <Button
-          className={
-            selectedLanguage === "py" ? pressedClasses : unPressedClasses
-          }
+          className={unPressedClasses}
         >
           py
         </Button>
       </Link>
       <Link href="/other-platforms">
         <Button
-          className={
-            selectedLanguage === "other-platforms"
-              ? pressedClasses
-              : unPressedClasses
-          }
+          className={unPressedClasses}
         >
           ...
         </Button>
@@ -132,15 +116,6 @@ const sharedClasses = clsx([
   "desktop:w-[110px]",
   "hover:text-white",
   "hover:bg-blue",
-]);
-
-const pressedClasses = clsx([
-  "mt-[1px]",
-  "text-white",
-  "bg-blue",
-  "shadow-none",
-  "tablet:mt-[3px]",
-  sharedClasses,
 ]);
 
 const unPressedClasses = clsx([

--- a/selfie.dev/src/components/HeroGifDemo.tsx
+++ b/selfie.dev/src/components/HeroGifDemo.tsx
@@ -144,7 +144,7 @@ export function IntroText() {
         "desktop:top-[345px]",
       ])}
     >
-      <p
+      <div
         className={clsx([
           "text-[20px]",
           "leading-[1.25em]",
@@ -155,7 +155,7 @@ export function IntroText() {
         Which is <br className="tablet:hidden" />{" "}
         literal, lensable
         <br /> and like a filesystem
-      </p>
+      </div>
       <Link href="/jvm/get-started">
         <Button
           className={clsx([

--- a/selfie.dev/src/components/HeroGifDemo.tsx
+++ b/selfie.dev/src/components/HeroGifDemo.tsx
@@ -126,8 +126,6 @@ const unPressedClasses = clsx([
   sharedClasses,
 ]);
 
-const THE_CONTEXT_WINDOW = "https://thecontextwindow.ai/p/temporarily-embarrassed-snapshots";
-
 export function IntroText() {
   return (
     <div
@@ -155,8 +153,8 @@ export function IntroText() {
         ])}
       >
         Which is <br className="tablet:hidden" />{" "}
-        <SectionLink title="literal" />, <SectionLink title="lensable" />
-        <br /> and <SectionLink title="like a filesystem" />
+        literal, lensable
+        <br /> and like a filesystem
       </p>
       <Link href="/jvm/get-started">
         <Button
@@ -190,18 +188,18 @@ export function IntroText() {
       >
         <p>
           Snapshot testing is the <br />{" "}
-          <a href={THE_CONTEXT_WINDOW} className="text-blue hover:underline cursor-pointer">fastest and most precise</a>
+          <span className="text-blue">fastest and most precise</span>
           <br />
           mechanism to{" "}
-          <a href={THE_CONTEXT_WINDOW} className="text-red hover:underline cursor-pointer">
+          <span className="text-red">
             record <br /> and specify
-          </a>{" "}
+          </span>{" "}
           the <br />
-          <a href={THE_CONTEXT_WINDOW} className="text-green hover:underline cursor-pointer">
+          <span className="text-green">
             behavior of your <br />
             system and its <br />
             components
-          </a>
+          </span>
           .
         </p>
         <p>

--- a/selfie.dev/src/components/HeroGifDemo.tsx
+++ b/selfie.dev/src/components/HeroGifDemo.tsx
@@ -1,0 +1,89 @@
+import clsx from "clsx";
+import { ButtonList } from "./ButtonList";
+import { IntroText } from "./IntroText";
+import { Logo } from "./Logo";
+import { Mascot } from "./Mascot";
+
+const sharedClasses = clsx([
+  "w-[34px]",
+  "h-[23px]",
+  "rounded-[4px]",
+  "text-[12px]",
+  "wide-phone:w-[44px]",
+  "tablet:w-[73px]",
+  "desktop:w-[110px]",
+  "hover:text-white",
+  "hover:bg-blue",
+]);
+
+const pressedClasses = clsx([
+  "mt-[1px]",
+  "text-white",
+  "bg-blue",
+  "shadow-none",
+  "tablet:mt-[3px]",
+  sharedClasses,
+]);
+
+const unPressedClasses = clsx([
+  "text-black",
+  "bg-white",
+  "shadow-button",
+  "tablet:shadow-button-tablet",
+  sharedClasses,
+]);
+
+export function HeroGifDemo() {
+  return (
+    <div
+      className={clsx([
+        "relative",
+        "h-[1009px]",
+        "wide-phone:h-[664px]",
+        "tablet:h-[825px]",
+        "desktop:h-[1150px]",
+      ])}
+    >
+      <Mascot />
+      <div
+        className={clsx([
+          "flex",
+          "justify-between",
+          "wide-phone:block",
+          "wide-phone:text-right",
+        ])}
+      >
+        <Logo />
+        <div
+          className={clsx([
+            "flex",
+            "flex-col",
+            "justify-between",
+            "pt-3",
+            "wide-phone:p-0",
+            "wide-phone:justify-center",
+            "wide-phone:items-end",
+            "wide-phone:h-[70px]",
+            "tablet:h-[140px]",
+            "tablet:gap-[15px]",
+          ])}
+        >
+          <p
+            className={clsx([
+              "font-sans",
+              "text-[16px]",
+              "wide-phone:text-[30px]",
+              "wide-phone:mb-2",
+              "tablet:text-[40px]",
+              "desktop:text-[60px]",
+            ])}
+          >
+            snapshot testing for
+          </p>
+          <ButtonList />
+        </div>
+      </div>
+      <IntroText />
+    </div>
+  );
+}

--- a/selfie.dev/src/pages/_app.tsx
+++ b/selfie.dev/src/pages/_app.tsx
@@ -44,7 +44,7 @@ export default function App({ Component, pageProps, router }: AppProps) {
         >
             {pageProps.showHeroLinks ? (pageProps.showHeroLinks === 'true' ? <Hero /> : <HeroGifDemo />) : <Navigation {...pageProps} />}
         </div>
-        <div className={clsx(["px-2", "wiede-phone:px-4"])}>
+        <div className={clsx(["px-2", "wide-phone:px-4"])}>
           <Component {...pageProps} />
         </div>
       </MDXProvider>

--- a/selfie.dev/src/pages/_app.tsx
+++ b/selfie.dev/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import { Hero } from "@/components/Hero";
+import { HeroGifDemo } from "@/components/HeroGifDemo";
 import { Navigation } from "@/components/Navigation/Navigation";
 import * as mdxComponents from "@/components/mdx";
 import "@/styles/tailwind.css";
@@ -28,6 +29,7 @@ export default function App({ Component, pageProps, router }: AppProps) {
           name="twitter:image"
           content={"https://selfie.dev/twitter-card.webp"}
         />
+        {pageProps.showHeroLinks === 'false' && <meta name="robots" content="noindex" />}
       </Head>
       <MDXProvider components={mdxComponents}>
         <div
@@ -40,9 +42,9 @@ export default function App({ Component, pageProps, router }: AppProps) {
             "wide-phone:py-2",
           ])}
         >
-          {pageProps.showHero ? <Hero /> : <Navigation {...pageProps} />}
+            {pageProps.showHeroLinks ? (pageProps.showHeroLinks === 'true' ? <Hero /> : <HeroGifDemo />) : <Navigation {...pageProps} />}
         </div>
-        <div className={clsx(["px-2", "wide-phone:px-4"])}>
+        <div className={clsx(["px-2", "wiede-phone:px-4"])}>
           <Component {...pageProps} />
         </div>
       </MDXProvider>

--- a/selfie.dev/src/pages/gif-demo/index.mdx
+++ b/selfie.dev/src/pages/gif-demo/index.mdx
@@ -1,0 +1,5 @@
+export const showHeroLinks = 'false';
+
+<div id="literal"></div>
+
+This just a demo, real homepage [lives here](/).

--- a/selfie.dev/src/pages/jvm/index.mdx
+++ b/selfie.dev/src/pages/jvm/index.mdx
@@ -1,7 +1,7 @@
 import { FooterCTA } from "@/components/FooterCTA/FooterCTA";
 import { NavHeading } from "@/components/NavHeading";
 
-export const showHero = true;
+export const showHeroLinks = 'true';
 export const title = "Selfie JVM Snapshot Testing";
 export const description = "Zero-config inline and disk snapshots for Java, Kotlin, and more. Features garbage collection, filesystem-like APIs for snapshot data, and novel techniques for storytelling within test code.";
 


### PR DESCRIPTION
The reason it was worth creating selfie instead of using an existing snapshot library is because of facets. You can use them for lots of things, but the thing which is easiest to describe is "snapshot html to disk, render its md as inline snapshot".

To show that, we need a page to snapshot. Our landing page is the obvious candidate, but it has so much text that it confused the example.

This PR introduces a new page, `https://selfie.dev/gif-demo` which is basically the landing page without the content.