### PR TITLE
Fix google search console errors

### DIFF
--- a/selfie.dev/package.json
+++ b/selfie.dev/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "cp src/pages/jvm/index.mdx src/pages/index.mdx && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/selfie.dev/public/_redirects
+++ b/selfie.dev/public/_redirects
@@ -1,4 +1,3 @@
-/ /jvm
 /js https://github.com/diffplug/selfie/issues/84
 /js/* https://github.com/diffplug/selfie/issues/84
 /py https://github.com/diffplug/selfie/issues/85

--- a/selfie.dev/src/pages/_app.tsx
+++ b/selfie.dev/src/pages/_app.tsx
@@ -30,6 +30,7 @@ export default function App({ Component, pageProps, router }: AppProps) {
           content={"https://selfie.dev/twitter-card.webp"}
         />
         {pageProps.showHeroLinks === 'false' && <meta name="robots" content="noindex" />}
+        {router.pathname === "/" && <link rel="canonical" href="https://selfie.dev/jvm" />}
       </Head>
       <MDXProvider components={mdxComponents}>
         <div


### PR DESCRIPTION
Instead of redirecting `/` to `/jvm`, we'll render `/` as a copy of `/jvm`, but with 

- `<link rel="canonical" href="https://selfie.dev/jvm"/>`