### PR TITLE
Introduce `TypedPath`

### DIFF
--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changes
+- (no user-facing changes) replaced terrible platform-specific `Path` with `TypedPath`. ([#184](https://github.com/diffplug/selfie/pull/184))
 
 ## [1.1.2] - 2024-01-30
 ### Fixed

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/CommentTracker.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/CommentTracker.kt
@@ -38,8 +38,8 @@ class CommentTracker {
     val needsRemoval: Boolean
       get() = this == ONCE
   }
-  private val cache = createCas(ArrayMap.empty<Path, WritableComment>())
-  fun pathsWithOnce(): Iterable<Path> =
+  private val cache = createCas(ArrayMap.empty<TypedPath, WritableComment>())
+  fun pathsWithOnce(): Iterable<TypedPath> =
       cache.get().mapNotNull { if (it.value == WritableComment.ONCE) it.key else null }
   fun hasWritableComment(call: CallStack, layout: SnapshotFileLayout): Boolean {
     val path = layout.sourcePathForCall(call.location) ?: return false
@@ -54,17 +54,17 @@ class CommentTracker {
   }
 
   companion object {
-    fun commentString(path: Path, fs: FS): Pair<String, Int> {
-      val (comment, line) = commentAndLine(path, fs)
+    fun commentString(typedPath: TypedPath, fs: FS): Pair<String, Int> {
+      val (comment, line) = commentAndLine(typedPath, fs)
       return when (comment) {
         WritableComment.NO_COMMENT -> throw UnsupportedOperationException()
         WritableComment.ONCE -> Pair("//selfieonce", line)
         WritableComment.FOREVER -> Pair("//SELFIEWRITE", line)
       }
     }
-    private fun commentAndLine(path: Path, fs: FS): Pair<WritableComment, Int> {
+    private fun commentAndLine(typedPath: TypedPath, fs: FS): Pair<WritableComment, Int> {
       // TODO: there is a bug here due to string constants, and non-C file comments
-      val content = Slice(fs.fileRead(path))
+      val content = Slice(fs.fileRead(typedPath))
       for (comment in listOf("//selfieonce", "// selfieonce", "//SELFIEWRITE", "// SELFIEWRITE")) {
         val index = content.indexOf(comment)
         if (index != -1) {

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/WriteTracker.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/WriteTracker.kt
@@ -120,7 +120,7 @@ class InlineWriteTracker : WriteTracker<CallLocation, LiteralValue<*>>() {
   }
   fun hasWrites(): Boolean = writes.isNotEmpty()
 
-  private class FileLineLiteral(val file: Path, val line: Int, val literal: LiteralValue<*>) :
+  private class FileLineLiteral(val file: TypedPath, val line: Int, val literal: LiteralValue<*>) :
       Comparable<FileLineLiteral> {
     override fun compareTo(other: FileLineLiteral): Int =
         compareValuesBy(this, other, { it.file }, { it.line })

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/WriteTracker.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/WriteTracker.kt
@@ -101,7 +101,7 @@ class InlineWriteTracker : WriteTracker<CallLocation, LiteralValue<*>>() {
     val file = layout.sourcePathForCall(call.location)
     if (literalValue.expected != null) {
       // if expected == null, it's a `toBe_TODO()`, so there's nothing to check
-      val content = SourceFile(layout.fs.name(file), layout.fs.fileRead(file))
+      val content = SourceFile(file.name, layout.fs.fileRead(file))
       val parsedValue =
           try {
             content.parseToBe(call.location.line).parseLiteral(literalValue.format)
@@ -139,14 +139,14 @@ class InlineWriteTracker : WriteTracker<CallLocation, LiteralValue<*>>() {
             .sorted()
 
     var file = writes.first().file
-    var content = SourceFile(layout.fs.name(file), layout.fs.fileRead(file))
+    var content = SourceFile(file.name, layout.fs.fileRead(file))
     var deltaLineNumbers = 0
     for (write in writes) {
       if (write.file != file) {
         layout.fs.fileWrite(file, content.asString)
         file = write.file
         deltaLineNumbers = 0
-        content = SourceFile(layout.fs.name(file), layout.fs.fileRead(file))
+        content = SourceFile(file.name, layout.fs.fileRead(file))
       }
       // parse the location within the file
       val line = write.line + deltaLineNumbers

--- a/jvm/selfie-lib/src/jsMain/kotlin/com/diffplug/selfie/guts/SnapshotStorage.js.kt
+++ b/jvm/selfie-lib/src/jsMain/kotlin/com/diffplug/selfie/guts/SnapshotStorage.js.kt
@@ -17,5 +17,3 @@ package com.diffplug.selfie.guts
 actual fun initStorage(): SnapshotStorage {
   TODO("Not yet implemented")
 }
-
-actual typealias Path = String

--- a/jvm/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/guts/SnapshotStorage.jvm.kt
+++ b/jvm/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/guts/SnapshotStorage.jvm.kt
@@ -23,5 +23,3 @@ actual fun initStorage(): SnapshotStorage {
         "Missing required artifact `com.diffplug.spotless:selfie-runner-junit5", e)
   }
 }
-
-actual typealias Path = java.io.File

--- a/jvm/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/guts/WriteTracker.jvm.kt
+++ b/jvm/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/guts/WriteTracker.jvm.kt
@@ -40,7 +40,7 @@ actual data class CallLocation(
     if (fileName != null) {
       return fileName
     }
-    return layout.sourcePathForCallMaybe(this)?.let { layout.fs.name(it) }
+    return layout.sourcePathForCallMaybe(this)?.let { it.name }
         ?: "${clazz.substringAfterLast('.')}.class"
   }
 

--- a/jvm/selfie-lib/src/jvmTest/kotlin/testpkg/RecordCallTest.kt
+++ b/jvm/selfie-lib/src/jvmTest/kotlin/testpkg/RecordCallTest.kt
@@ -17,7 +17,7 @@ package testpkg
 
 import com.diffplug.selfie.guts.CallLocation
 import com.diffplug.selfie.guts.FS
-import com.diffplug.selfie.guts.Path
+import com.diffplug.selfie.guts.TypedPath
 import com.diffplug.selfie.guts.SnapshotFileLayout
 import com.diffplug.selfie.guts.recordCall
 import io.kotest.matchers.ints.shouldBeGreaterThan
@@ -30,14 +30,14 @@ class RecordCallTest {
     val stack = recordCall(false)
     val layout =
         object : SnapshotFileLayout {
-          override val rootFolder: Path
+          override val rootFolder: TypedPath
             get() = TODO()
           override val fs: FS
             get() = TODO()
           override val allowMultipleEquivalentWritesToOneLocation: Boolean
             get() = TODO()
-          override fun sourcePathForCall(call: CallLocation) = Path("testpkg/RecordCallTest.kt")
-          override fun sourcePathForCallMaybe(call: CallLocation): Path? = sourcePathForCall(call)
+          override fun sourcePathForCall(call: CallLocation) = TypedPath("testpkg/RecordCallTest.kt")
+          override fun sourcePathForCallMaybe(call: CallLocation): TypedPath? = sourcePathForCall(call)
         }
     stack.location.ideLink(layout) shouldBe
         "testpkg.RecordCallTest.testRecordCall(RecordCallTest.kt:30)"

--- a/jvm/selfie-lib/src/jvmTest/kotlin/testpkg/RecordCallTest.kt
+++ b/jvm/selfie-lib/src/jvmTest/kotlin/testpkg/RecordCallTest.kt
@@ -17,8 +17,8 @@ package testpkg
 
 import com.diffplug.selfie.guts.CallLocation
 import com.diffplug.selfie.guts.FS
-import com.diffplug.selfie.guts.TypedPath
 import com.diffplug.selfie.guts.SnapshotFileLayout
+import com.diffplug.selfie.guts.TypedPath
 import com.diffplug.selfie.guts.recordCall
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
@@ -36,8 +36,10 @@ class RecordCallTest {
             get() = TODO()
           override val allowMultipleEquivalentWritesToOneLocation: Boolean
             get() = TODO()
-          override fun sourcePathForCall(call: CallLocation) = TypedPath("testpkg/RecordCallTest.kt")
-          override fun sourcePathForCallMaybe(call: CallLocation): TypedPath? = sourcePathForCall(call)
+          override fun sourcePathForCall(call: CallLocation) =
+              TypedPath("testpkg/RecordCallTest.kt")
+          override fun sourcePathForCallMaybe(call: CallLocation): TypedPath? =
+              sourcePathForCall(call)
         }
     stack.location.ideLink(layout) shouldBe
         "testpkg.RecordCallTest.testRecordCall(RecordCallTest.kt:30)"

--- a/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieGC.kt
+++ b/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieGC.kt
@@ -41,11 +41,8 @@ private val testAnnotations =
 internal fun findStaleSnapshotFiles(layout: SnapshotFileLayoutJUnit5): List<String> {
   return layout.fs.fileWalk(layout.rootFolder) { walk ->
     walk
-        .filter { layout.fs.name(it).endsWith(layout.extension) }
-        .map {
-          layout.subpathToClassname(
-              layout.rootFolder.toPath().relativize(it.toPath()).toString().replace('\\', '/'))
-        }
+        .filter { it.name.endsWith(layout.extension) }
+        .map { layout.subpathToClassname(layout.rootFolder.relativize(it)) }
         .filter { !classExistsAndHasTests(it) }
         .toMutableList()
   }

--- a/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotFileLayoutJUnit5.kt
+++ b/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotFileLayoutJUnit5.kt
@@ -17,8 +17,8 @@ package com.diffplug.selfie.junit5
 
 import com.diffplug.selfie.guts.CallLocation
 import com.diffplug.selfie.guts.FS
-import com.diffplug.selfie.guts.TypedPath
 import com.diffplug.selfie.guts.SnapshotFileLayout
+import com.diffplug.selfie.guts.TypedPath
 
 class SnapshotFileLayoutJUnit5(settings: SelfieSettingsAPI, override val fs: FS) :
     SnapshotFileLayout {

--- a/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotFileLayoutJUnit5.kt
+++ b/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotFileLayoutJUnit5.kt
@@ -17,22 +17,22 @@ package com.diffplug.selfie.junit5
 
 import com.diffplug.selfie.guts.CallLocation
 import com.diffplug.selfie.guts.FS
-import com.diffplug.selfie.guts.Path
+import com.diffplug.selfie.guts.TypedPath
 import com.diffplug.selfie.guts.SnapshotFileLayout
 
 class SnapshotFileLayoutJUnit5(settings: SelfieSettingsAPI, override val fs: FS) :
     SnapshotFileLayout {
   internal var smuggledError: Throwable? =
       if (settings is SelfieSettingsSmuggleError) settings.error else null
-  override val rootFolder = Path.ofFolder(settings.rootFolder.absolutePath)
+  override val rootFolder = TypedPath.ofFolder(settings.rootFolder.absolutePath)
   private val otherSourceRoots = settings.otherSourceRoots
   override val allowMultipleEquivalentWritesToOneLocation =
       settings.allowMultipleEquivalentWritesToOneLocation
   val snapshotFolderName = settings.snapshotFolderName
   internal val unixNewlines = inferDefaultLineEndingIsUnix(rootFolder, fs)
   val extension: String = ".ss"
-  private val cache = ThreadLocal<Pair<CallLocation, Path>?>()
-  override fun sourcePathForCall(call: CallLocation): Path {
+  private val cache = ThreadLocal<Pair<CallLocation, TypedPath>?>()
+  override fun sourcePathForCall(call: CallLocation): TypedPath {
     smuggledError?.let { throw it }
     val nonNull =
         sourcePathForCallMaybe(call)
@@ -40,7 +40,7 @@ class SnapshotFileLayoutJUnit5(settings: SelfieSettingsAPI, override val fs: FS)
                 "Couldn't find source file for $call, looked in $rootFolder and $otherSourceRoots, maybe there are other source roots?")
     return nonNull
   }
-  override fun sourcePathForCallMaybe(call: CallLocation): Path? {
+  override fun sourcePathForCallMaybe(call: CallLocation): TypedPath? {
     val cached = cache.get()
     if (cached?.first?.samePathAs(call) == true) {
       return cached.second
@@ -52,13 +52,13 @@ class SnapshotFileLayoutJUnit5(settings: SelfieSettingsAPI, override val fs: FS)
       path
     }
   }
-  private fun computePathForCall(call: CallLocation): Path? =
+  private fun computePathForCall(call: CallLocation): TypedPath? =
       sequence {
             yield(rootFolder)
-            yieldAll(otherSourceRoots.map { Path.ofFolder(it.absolutePath) })
+            yieldAll(otherSourceRoots.map { TypedPath.ofFolder(it.absolutePath) })
           }
           .firstNotNullOfOrNull { computePathForCall(it, call) }
-  private fun computePathForCall(folder: Path, call: CallLocation): Path? {
+  private fun computePathForCall(folder: TypedPath, call: CallLocation): TypedPath? {
     if (call.fileName != null) {
       return fs.fileWalk(folder) { walk -> walk.filter { it.name == call.fileName }.firstOrNull() }
     }
@@ -67,9 +67,9 @@ class SnapshotFileLayoutJUnit5(settings: SelfieSettingsAPI, override val fs: FS)
     val possibleNames = likelyExtensions.map { "$fileWithoutExtension.$it" }.toSet()
     return fs.fileWalk(folder) { walk -> walk.filter { it.name in possibleNames }.firstOrNull() }
   }
-  fun snapshotPathForClass(className: String): Path {
+  fun snapshotPathForClass(className: String): TypedPath {
     val lastDot = className.lastIndexOf('.')
-    val classFolder: Path
+    val classFolder: TypedPath
     val filename: String
     if (lastDot == -1) {
       classFolder = rootFolder
@@ -105,7 +105,7 @@ class SnapshotFileLayoutJUnit5(settings: SelfieSettingsAPI, override val fs: FS)
      * It's pretty easy to preserve the line endings of existing snapshot files, but it's a bit
      * harder to create a fresh snapshot file with the correct line endings.
      */
-    private fun inferDefaultLineEndingIsUnix(rootFolder: Path, fs: FS): Boolean {
+    private fun inferDefaultLineEndingIsUnix(rootFolder: TypedPath, fs: FS): Boolean {
       return fs.fileWalk(rootFolder) { walk ->
         walk
             .mapNotNull {

--- a/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotStorageJUnit5.kt
+++ b/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotStorageJUnit5.kt
@@ -22,10 +22,10 @@ import com.diffplug.selfie.guts.DiskWriteTracker
 import com.diffplug.selfie.guts.FS
 import com.diffplug.selfie.guts.InlineWriteTracker
 import com.diffplug.selfie.guts.LiteralValue
-import com.diffplug.selfie.guts.TypedPath
 import com.diffplug.selfie.guts.SnapshotFileLayout
 import com.diffplug.selfie.guts.SnapshotStorage
 import com.diffplug.selfie.guts.SourceFile
+import com.diffplug.selfie.guts.TypedPath
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.concurrent.ConcurrentSkipListSet


### PR DESCRIPTION
In the `guts` package we had a `Path` class which was a `java.io.File` in the JVM and a `String` in JS. This was extremely confusing.

`Path` has been replaced by `TypedPath`, which is just a `String absolutePath` where a trailing slash is used to signify that the path is or isn't a folder. This makes a lot of the "path math" we do easier and cheaper.

Note that this is technically a breaking change to the public API of the `lib` package, but the `guts` package is meant to be private.