### PR TITLE
Make it easier to mix Kotest and vanilla JUnit5 tests

### DIFF
--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Selfie.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Selfie.kt
@@ -16,6 +16,7 @@
 package com.diffplug.selfie
 
 import com.diffplug.selfie.guts.CallStack
+import com.diffplug.selfie.guts.CoroutineDiskStorage
 import com.diffplug.selfie.guts.DiskSnapshotTodo
 import com.diffplug.selfie.guts.DiskStorage
 import com.diffplug.selfie.guts.LiteralBoolean
@@ -27,6 +28,7 @@ import com.diffplug.selfie.guts.LiteralValue
 import com.diffplug.selfie.guts.SnapshotSystem
 import com.diffplug.selfie.guts.initSnapshotSystem
 import com.diffplug.selfie.guts.recordCall
+import kotlin.coroutines.CoroutineContext
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.jvm.JvmOverloads
@@ -44,23 +46,7 @@ class Later internal constructor(private val disk: DiskStorage) {
       subsToKeep.forEach { disk.keep(it) }
     }
   }
-}
-
-object SelfieSuspend {
-  private suspend fun disk() = Selfie.system.diskCoroutine()
-  suspend fun <T> expectSelfie(actual: T, camera: Camera<T>) = expectSelfie(camera.snapshot(actual))
-  suspend fun expectSelfie(actual: String) = expectSelfie(Snapshot.of(actual))
-  suspend fun expectSelfie(actual: ByteArray) = expectSelfie(Snapshot.of(actual))
-  suspend fun expectSelfie(actual: Snapshot) = Selfie.DiskSelfie(actual, disk())
-  suspend fun preserveSelfiesOnDisk(vararg subsToKeep: String) {
-    val disk = disk()
-    if (subsToKeep.isEmpty()) {
-      disk.keep(null)
-    } else {
-      subsToKeep.forEach { disk.keep(it) }
-    }
-  }
-  suspend fun later() = Later(disk())
+  fun coroutineContextElement(): CoroutineContext.Element = CoroutineDiskStorage(disk)
 }
 
 object Selfie {

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Selfie.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Selfie.kt
@@ -16,7 +16,6 @@
 package com.diffplug.selfie
 
 import com.diffplug.selfie.guts.CallStack
-import com.diffplug.selfie.guts.CoroutineDiskStorage
 import com.diffplug.selfie.guts.DiskSnapshotTodo
 import com.diffplug.selfie.guts.DiskStorage
 import com.diffplug.selfie.guts.LiteralBoolean
@@ -28,7 +27,6 @@ import com.diffplug.selfie.guts.LiteralValue
 import com.diffplug.selfie.guts.SnapshotSystem
 import com.diffplug.selfie.guts.initSnapshotSystem
 import com.diffplug.selfie.guts.recordCall
-import kotlin.coroutines.CoroutineContext
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.jvm.JvmOverloads
@@ -46,7 +44,6 @@ class Later internal constructor(private val disk: DiskStorage) {
       subsToKeep.forEach { disk.keep(it) }
     }
   }
-  fun coroutineContextElement(): CoroutineContext.Element = CoroutineDiskStorage(disk)
 }
 
 object Selfie {

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/SelfieSuspend.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/SelfieSuspend.kt
@@ -15,8 +15,12 @@
  */
 package com.diffplug.selfie
 
+import com.diffplug.selfie.guts.CoroutineDiskStorage
+import kotlin.coroutines.coroutineContext
+
 object SelfieSuspend {
-  private suspend fun disk() = Selfie.system.diskCoroutine()
+  private suspend fun disk() =
+      coroutineContext[CoroutineDiskStorage.Key]?.disk ?: TODO("THREADING GUIDE (TODO)")
   suspend fun <T> expectSelfie(actual: T, camera: Camera<T>) = expectSelfie(camera.snapshot(actual))
   suspend fun expectSelfie(actual: String) = expectSelfie(Snapshot.of(actual))
   suspend fun expectSelfie(actual: ByteArray) = expectSelfie(Snapshot.of(actual))

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/SelfieSuspend.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/SelfieSuspend.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.selfie
+
+object SelfieSuspend {
+  private suspend fun disk() = Selfie.system.diskCoroutine()
+  suspend fun <T> expectSelfie(actual: T, camera: Camera<T>) = expectSelfie(camera.snapshot(actual))
+  suspend fun expectSelfie(actual: String) = expectSelfie(Snapshot.of(actual))
+  suspend fun expectSelfie(actual: ByteArray) = expectSelfie(Snapshot.of(actual))
+  suspend fun expectSelfie(actual: Snapshot) = Selfie.DiskSelfie(actual, disk())
+  suspend fun preserveSelfiesOnDisk(vararg subsToKeep: String) {
+    val disk = disk()
+    if (subsToKeep.isEmpty()) {
+      disk.keep(null)
+    } else {
+      subsToKeep.forEach { disk.keep(it) }
+    }
+  }
+  suspend fun later() = Later(disk())
+}

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotSystem.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotSystem.kt
@@ -17,6 +17,15 @@ package com.diffplug.selfie.guts
 
 import com.diffplug.selfie.Mode
 import com.diffplug.selfie.Snapshot
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/** Used by [com.diffplug.selfie.SelfieSuspend]. */
+class CoroutineDiskStorage(val disk: DiskStorage) : AbstractCoroutineContextElement(Key) {
+  override val key = Key
+
+  companion object Key : CoroutineContext.Key<CoroutineDiskStorage>
+}
 
 /** A unix-style path where trailing-slash means it is a folder. */
 data class TypedPath(val absolutePath: String) : Comparable<TypedPath> {

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotSystem.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotSystem.kt
@@ -99,8 +99,6 @@ interface SnapshotSystem {
   fun writeInline(literalValue: LiteralValue<*>, call: CallStack)
   /** Returns the DiskStorage for the test associated with this thread, else error. */
   fun diskThreadLocal(): DiskStorage
-  /** Returns the DiskStorage for the test associated with this coroutine, else error. */
-  suspend fun diskCoroutine(): DiskStorage
 }
 
 /** Represents the disk storage for a specific test. */

--- a/jvm/selfie-runner-junit5/build.gradle
+++ b/jvm/selfie-runner-junit5/build.gradle
@@ -16,6 +16,7 @@ dependencies {
   api project(':selfie-lib')
   implementation 'org.junit.platform:junit-platform-launcher:1.0.0'
   compileOnly "org.junit.jupiter:junit-jupiter-api:5.0.0"
+  compileOnly "io.kotest:kotest-framework-engine:$ver_KOTEST"
 
   testImplementation "com.squareup.okio:okio:$ver_OKIO"
   testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:$ver_KOTLIN_TEST"

--- a/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieExtension.kt
+++ b/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieExtension.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.selfie.junit5
+
+import com.diffplug.selfie.guts.CoroutineDiskStorage
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
+import io.kotest.core.extensions.TestCaseExtension
+import io.kotest.core.listeners.AfterProjectListener
+import io.kotest.core.listeners.BeforeSpecListener
+import io.kotest.core.listeners.FinalizeSpecListener
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import kotlin.reflect.KClass
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.withContext
+
+class SelfieExtension(projectConfig: AbstractProjectConfig) :
+    Extension, BeforeSpecListener, TestCaseExtension, FinalizeSpecListener, AfterProjectListener {
+  override suspend fun beforeSpec(spec: Spec) {
+    SnapshotSystemJUnit5.forClass(spec.javaClass.name).incrementContainers()
+  }
+  override suspend fun intercept(
+      testCase: TestCase,
+      execute: suspend (TestCase) -> TestResult
+  ): TestResult {
+    val file = SnapshotSystemJUnit5.forClass(testCase.spec::class.java.name)
+    val coroutineLocal = CoroutineDiskStorage(DiskStorageJUnit5(file, testCase.name.testName))
+    return withContext(currentCoroutineContext() + coroutineLocal) {
+      file.startTest(testCase.name.testName, null)
+      val result = execute(testCase)
+      file.finishedTestWithSuccess(testCase.name.testName, null, result.isSuccess)
+      result
+    }
+  }
+  override suspend fun finalizeSpec(
+      kclass: KClass<out Spec>,
+      results: Map<TestCase, TestResult>,
+  ) {
+    SnapshotSystemJUnit5.forClass(kclass.java.name)
+        .decrementContainersWithSuccess(results.values.all { it.isSuccess })
+  }
+  /**
+   * If you run from the CLI, `SelfieTestExecutionListener` will run and so will `afterProject`
+   * below If you run using the Kotest IDE plugin
+   * - if you run a whole spec, `SelfieTestExecutionListener` will run and so will `afterProject`
+   *   below
+   * - if you run a single test, `SelfieTestExecutionListener` will not run, but `afterProject`
+   *   below will
+   */
+  override suspend fun afterProject() {
+    SnapshotSystemJUnit5.finishedAllTests()
+  }
+}

--- a/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
+++ b/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
@@ -27,7 +27,7 @@ class SelfieTestExecutionListener : TestExecutionListener {
   private val system = SnapshotSystemJUnit5
   override fun executionStarted(testIdentifier: TestIdentifier) {
     try {
-      if (isRoot(testIdentifier)) return
+      if (isRootOrKotest(testIdentifier)) return
       val (clazz, test) = parseClassTest(testIdentifier)
       val snapshotFile = system.forClass(clazz)
       if (test == null) {
@@ -57,7 +57,7 @@ class SelfieTestExecutionListener : TestExecutionListener {
       testExecutionResult: TestExecutionResult
   ) {
     try {
-      if (isRoot(testIdentifier)) return
+      if (isRootOrKotest(testIdentifier)) return
       val (clazz, test) = parseClassTest(testIdentifier)
       val isSuccess = testExecutionResult.status == TestExecutionResult.Status.SUCCESSFUL
       val snapshotFile = system.forClass(clazz)
@@ -73,7 +73,8 @@ class SelfieTestExecutionListener : TestExecutionListener {
   override fun testPlanExecutionFinished(testPlan: TestPlan?) {
     system.finishedAllTests()
   }
-  private fun isRoot(testIdentifier: TestIdentifier) = testIdentifier.parentId.isEmpty
+  private fun isRootOrKotest(testIdentifier: TestIdentifier) =
+      testIdentifier.parentId.isEmpty || testIdentifier.uniqueId.startsWith("[engine:kotest]")
   private fun parseClassTest(testIdentifier: TestIdentifier): Pair<String, String?> {
     return when (val source = testIdentifier.source.get()) {
       is ClassSource ->

--- a/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotSystemJUnit5.kt
+++ b/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotSystemJUnit5.kt
@@ -91,7 +91,6 @@ internal object SnapshotSystemJUnit5 : SnapshotSystem {
   override fun writeInline(literalValue: LiteralValue<*>, call: CallStack) {
     inlineWriteTracker.record(call, literalValue, layout)
   }
-  override suspend fun diskCoroutine(): DiskStorage = TODO("THREADING GUIDE (TODO)")
   override fun diskThreadLocal(): DiskStorage = diskThreadLocalTyped()
   fun finishedAllTests() {
     val snapshotsFilesWrittenToDisk =
@@ -227,7 +226,7 @@ internal object SnapshotSystemJUnit5 : SnapshotSystem {
   //////////
 }
 
-private data class DiskStorageJUnit5(val file: SnapshotFileProgress, val test: String) :
+internal data class DiskStorageJUnit5(val file: SnapshotFileProgress, val test: String) :
     DiskStorage, Comparable<DiskStorageJUnit5> {
   override fun readDisk(sub: String, call: CallStack): Snapshot? = file.read(test, suffix(sub))
   override fun writeDisk(actual: Snapshot, sub: String, call: CallStack) {

--- a/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotSystemJUnit5.kt
+++ b/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotSystemJUnit5.kt
@@ -185,7 +185,8 @@ internal object SnapshotSystemJUnit5 : SnapshotSystem {
         "Test $finishing($uniqueId) is ending on the same thread it started, but we found $prev in its spot unexpectedly."
       }
     } else {
-      // we got notified on a different thread than we started (Kotest does this, maybe others too)
+      // we got notified on a different thread than we started (Kotest does this, maybe others
+      // too)
       val prevMap = threadMap.getAndUpdate { it.minusOrNoOp(prevThreadId, finishing) }
       val prev = prevMap[prevThreadId]
       if (prev == finishing) {
@@ -261,11 +262,11 @@ internal class SnapshotFileProgress(val system: SnapshotSystemJUnit5, val classN
   private val hasFailed = AtomicBoolean(false)
 
   /** Assigns this thread to store disk snapshots within this file with the name `test`. */
-  fun startTest(test: String, uniqueId: String) {
+  fun startTest(test: String, uniqueId: String?) {
     check(test.indexOf('/') == -1) { "Test name cannot contain '/', was $test" }
     assertNotTerminated()
     tests.updateAndGet { it.plusOrNoOp(test, WithinTestGC()) }
-    system.startThreadLocal(this, test, uniqueId)
+    uniqueId?.let { system.startThreadLocal(this, test, uniqueId) }
   }
   /**
    * Stops assigning this thread to store snapshots within this file at `test`, and if successful
@@ -273,12 +274,12 @@ internal class SnapshotFileProgress(val system: SnapshotSystemJUnit5, val classN
    * times (as in `@ParameterizedTest`), and GC will only happen if all runs of the test are
    * successful.
    */
-  fun finishedTestWithSuccess(test: String, uniqueId: String, success: Boolean) {
+  fun finishedTestWithSuccess(test: String, uniqueId: String?, success: Boolean) {
     assertNotTerminated()
     if (!success) {
       tests.get()[test]!!.keepAll()
     }
-    system.finishThreadLocal(this, test, uniqueId)
+    uniqueId?.let { system.finishThreadLocal(this, test, uniqueId) }
   }
   private fun finishedClassWithSuccess(success: Boolean) {
     assertNotTerminated()

--- a/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SelfieExtension.kt
+++ b/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SelfieExtension.kt
@@ -15,7 +15,7 @@
  */
 package com.diffplug.selfie.kotest
 
-import com.diffplug.selfie.guts.DiskStorage
+import com.diffplug.selfie.guts.CoroutineDiskStorage
 import io.kotest.core.extensions.Extension
 import io.kotest.core.extensions.TestCaseExtension
 import io.kotest.core.listeners.AfterProjectListener
@@ -25,17 +25,9 @@ import io.kotest.core.source.SourceRef
 import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
-import kotlin.coroutines.AbstractCoroutineContextElement
-import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.KClass
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
-
-internal class CoroutineDiskStorage(val disk: DiskStorage) : AbstractCoroutineContextElement(Key) {
-  override val key = Key
-
-  companion object Key : CoroutineContext.Key<CoroutineDiskStorage>
-}
 
 object SelfieExtension :
     Extension, FinalizeSpecListener, TestCaseExtension, IgnoredSpecListener, AfterProjectListener {

--- a/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SnapshotSystemKotest.kt
+++ b/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SnapshotSystemKotest.kt
@@ -23,7 +23,6 @@ import com.diffplug.selfie.SnapshotFile
 import com.diffplug.selfie.SnapshotValueReader
 import com.diffplug.selfie.guts.CallStack
 import com.diffplug.selfie.guts.CommentTracker
-import com.diffplug.selfie.guts.CoroutineDiskStorage
 import com.diffplug.selfie.guts.DiskStorage
 import com.diffplug.selfie.guts.DiskWriteTracker
 import com.diffplug.selfie.guts.InlineWriteTracker
@@ -34,7 +33,6 @@ import com.diffplug.selfie.guts.SourceFile
 import com.diffplug.selfie.guts.TypedPath
 import com.diffplug.selfie.guts.WithinTestGC
 import com.diffplug.selfie.guts.atomic
-import kotlin.coroutines.coroutineContext
 import kotlin.jvm.JvmStatic
 
 internal object SnapshotSystemKotest : SnapshotSystem {
@@ -70,8 +68,6 @@ internal object SnapshotSystemKotest : SnapshotSystem {
   override fun writeInline(literalValue: LiteralValue<*>, call: CallStack) {
     inlineWriteTracker.record(call, literalValue, layout)
   }
-  override suspend fun diskCoroutine(): DiskStorage =
-      coroutineContext[CoroutineDiskStorage.Key]?.disk ?: TODO("THREADING GUIDE (TODO)")
   override fun diskThreadLocal(): DiskStorage = TODO("THREADING GUIDE (TODO)")
   fun finishedAllTests() {
     val snapshotsFilesWrittenToDisk =

--- a/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SnapshotSystemKotest.kt
+++ b/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SnapshotSystemKotest.kt
@@ -23,6 +23,7 @@ import com.diffplug.selfie.SnapshotFile
 import com.diffplug.selfie.SnapshotValueReader
 import com.diffplug.selfie.guts.CallStack
 import com.diffplug.selfie.guts.CommentTracker
+import com.diffplug.selfie.guts.CoroutineDiskStorage
 import com.diffplug.selfie.guts.DiskStorage
 import com.diffplug.selfie.guts.DiskWriteTracker
 import com.diffplug.selfie.guts.InlineWriteTracker

--- a/jvm/undertest-junit5-kotest/src/test/kotlin/undertest/junit5/JunitKotestProjectConfig.kt
+++ b/jvm/undertest-junit5-kotest/src/test/kotlin/undertest/junit5/JunitKotestProjectConfig.kt
@@ -1,0 +1,8 @@
+package undertest.junit5
+
+import com.diffplug.selfie.junit5.SelfieExtension
+import io.kotest.core.config.AbstractProjectConfig
+
+class JunitKotestProjectConfig : AbstractProjectConfig() {
+  override fun extensions() = listOf(SelfieExtension(this))
+}

--- a/jvm/undertest-junit5-kotest/src/test/kotlin/undertest/junit5/UT_KotestConcurrencyStressTest.kt
+++ b/jvm/undertest-junit5-kotest/src/test/kotlin/undertest/junit5/UT_KotestConcurrencyStressTest.kt
@@ -1,6 +1,6 @@
 package undertest.junit5
 
-import com.diffplug.selfie.Selfie
+import com.diffplug.selfie.SelfieSuspend.expectSelfie
 import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.delay
 
@@ -10,9 +10,8 @@ class UT_KotestConcurrencyStressTest :
       for (d in 1..1000) {
         val digit = d
         test(String.format("test %04d", digit)) {
-          val later = Selfie.later()
           delay(digit.toLong())
-          later.expectSelfie(digit.toString()).toMatchDisk()
+          expectSelfie(digit.toString()).toMatchDisk()
         }
       }
     })

--- a/jvm/undertest-junit5-kotest/src/test/kotlin/undertest/junit5/UT_KotestFunSpecTest.kt
+++ b/jvm/undertest-junit5-kotest/src/test/kotlin/undertest/junit5/UT_KotestFunSpecTest.kt
@@ -1,6 +1,6 @@
 package undertest.junit5
 
-import com.diffplug.selfie.Selfie.expectSelfie
+import com.diffplug.selfie.SelfieSuspend.expectSelfie
 import io.kotest.core.spec.style.FunSpec
 
 class UT_KotestFunSpecTest :

--- a/jvm/undertest-junit5-kotest/src/test/kotlin/undertest/junit5/UT_KotestStringSpecTest.kt
+++ b/jvm/undertest-junit5-kotest/src/test/kotlin/undertest/junit5/UT_KotestStringSpecTest.kt
@@ -1,6 +1,6 @@
 package undertest.junit5
 
-import com.diffplug.selfie.Selfie.expectSelfie
+import com.diffplug.selfie.SelfieSuspend.expectSelfie
 import io.kotest.core.spec.style.StringSpec
 
 class UT_KotestStringSpecTest :


### PR DESCRIPTION
- Added a `compileOnly` dependency onto `kotest` in `selfie-runner-junit5`
- Implemented a `SelfieExtension` that takes an `AbstractProjectConfiguration` in its constructor to enforce project-wide application
- Simplified our coroutine-local implementation to unify the `selfie-runner-junit5` and `selfie-runner-kotest`