### PR TITLE
Massive simplification to `SnapshotSystemJUnit5`

### DIFF
--- a/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieExtension.kt
+++ b/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieExtension.kt
@@ -41,9 +41,9 @@ class SelfieExtension(projectConfig: AbstractProjectConfig) :
     val file = SnapshotSystemJUnit5.forClass(testCase.spec::class.java.name)
     val coroutineLocal = CoroutineDiskStorage(DiskStorageJUnit5(file, testCase.name.testName))
     return withContext(currentCoroutineContext() + coroutineLocal) {
-      file.startTest(testCase.name.testName, null)
+      file.startTest(testCase.name.testName, false)
       val result = execute(testCase)
-      file.finishedTestWithSuccess(testCase.name.testName, null, result.isSuccess)
+      file.finishedTestWithSuccess(testCase.name.testName, false, result.isSuccess)
       result
     }
   }

--- a/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
+++ b/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SelfieTestExecutionListener.kt
@@ -33,7 +33,7 @@ class SelfieTestExecutionListener : TestExecutionListener {
       if (test == null) {
         snapshotFile.incrementContainers()
       } else {
-        system.forClass(clazz).startTest(test, testIdentifier.uniqueId)
+        system.forClass(clazz).startTest(test, true)
       }
     } catch (e: Throwable) {
       system.layout.smuggledError.set(e)
@@ -64,7 +64,7 @@ class SelfieTestExecutionListener : TestExecutionListener {
       if (test == null) {
         snapshotFile.decrementContainersWithSuccess(isSuccess)
       } else {
-        snapshotFile.finishedTestWithSuccess(test, testIdentifier.uniqueId, isSuccess)
+        snapshotFile.finishedTestWithSuccess(test, true, isSuccess)
       }
     } catch (e: Throwable) {
       system.layout.smuggledError.set(e)


### PR DESCRIPTION
If Kotest only works with the Kotest extension, then the regular JUnit runner can be *a lot* simpler.