### PR TITLE
Improve `selfie-runner-kotest` settings

### DIFF
--- a/jvm/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/guts/SnapshotSystem.jvm.kt
+++ b/jvm/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/guts/SnapshotSystem.jvm.kt
@@ -18,7 +18,7 @@ actual fun initSnapshotSystem(): SnapshotSystem {
   val placesToLook =
       listOf(
           "com.diffplug.selfie.junit5.SnapshotSystemJUnit5",
-          "com.diffplug.selfie.kotest.SnapshotSystemKotest")
+          "com.diffplug.selfie.kotest.SelfieExtension")
   val classesThatExist =
       placesToLook.mapNotNull {
         try {

--- a/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SelfieExtension.kt
+++ b/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SelfieExtension.kt
@@ -16,6 +16,8 @@
 package com.diffplug.selfie.kotest
 
 import com.diffplug.selfie.guts.CoroutineDiskStorage
+import com.diffplug.selfie.guts.SnapshotSystem
+import com.diffplug.selfie.guts.atomic
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
 import io.kotest.core.extensions.TestCaseExtension
@@ -25,6 +27,7 @@ import io.kotest.core.source.SourceRef
 import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
+import kotlin.jvm.JvmStatic
 import kotlin.reflect.KClass
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
@@ -33,8 +36,28 @@ import kotlinx.coroutines.withContext
  * Add this to your [AbstractProjectConfig], see [here](https://selfie.dev/jvm/kotest) for
  * high-level docs.
  */
-class SelfieExtension(projectConfig: AbstractProjectConfig) :
-    Extension, TestCaseExtension, FinalizeSpecListener, AfterProjectListener {
+class SelfieExtension(
+    projectConfig: AbstractProjectConfig,
+    settingsAPI: SelfieSettingsAPI = SelfieSettingsAPI()
+) : Extension, TestCaseExtension, FinalizeSpecListener, AfterProjectListener {
+  private val system = SnapshotSystemKotest(settingsAPI)
+
+  companion object {
+    private val snapshotSystem = atomic(null as SnapshotSystem?)
+
+    @JvmStatic
+    fun initStorage(): SnapshotSystem =
+        snapshotSystem.get()
+            ?: throw IllegalStateException(
+                "SelfieExtension wasn't added to the AbstractProjectConfig")
+  }
+
+  init {
+    snapshotSystem.updateAndGet {
+      require(it == null) { "SnapshotSystemKotest should only be initialized once" }
+      system
+    }
+  }
   private fun snapshotFileFor(testCase: TestCase): SnapshotFileProgress {
     val classOrFilename: String =
         when (val source = testCase.source) {
@@ -42,7 +65,7 @@ class SelfieExtension(projectConfig: AbstractProjectConfig) :
           is SourceRef.FileSource -> source.fileName
           is SourceRef.None -> TODO("Handle SourceRef.None")
         }
-    return SnapshotSystemKotest.forClassOrFilename(classOrFilename)
+    return system.forClassOrFilename(classOrFilename)
   }
   /** Called for every test method. */
   override suspend fun intercept(
@@ -73,6 +96,6 @@ class SelfieExtension(projectConfig: AbstractProjectConfig) :
     file.finishedClassWithSuccess(results.entries.all { it.value.isSuccess })
   }
   override suspend fun afterProject() {
-    SnapshotSystemKotest.finishedAllTests()
+    system.finishedAllTests()
   }
 }

--- a/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SelfieSettingsAPI.kt
+++ b/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SelfieSettingsAPI.kt
@@ -22,8 +22,6 @@ import okio.Path.Companion.toPath
 internal expect fun readUserDir(): String
 
 internal expect fun readEnvironmentVariable(name: String): String?
-
-internal expect fun instantiateSettingsAt(name: String): SelfieSettingsAPI
 internal fun calcMode(): Mode {
   val override = readEnvironmentVariable("selfie") ?: readEnvironmentVariable("SELFIE")
   if (override != null) {
@@ -104,27 +102,6 @@ open class SelfieSettingsAPI {
             "src/jvmTest/kotlin",
             "src/jsTest/kotlin",
             "src/test/resources")
-    internal fun initialize(): SelfieSettingsAPI {
-      try {
-        val settings = readEnvironmentVariable("SELFIE_SETTINGS")
-        if (settings != null && settings.isNotBlank()) {
-          try {
-            return instantiateSettingsAt(settings)
-          } catch (e: Throwable) {
-            throw Error(
-                "The system property selfie.settings was set to $settings, but that class could not be found.",
-                e)
-          }
-        }
-        try {
-          return instantiateSettingsAt("selfie.SelfieSettings")
-        } catch (e: Throwable) {
-          return SelfieSettingsAPI()
-        }
-      } catch (e: Throwable) {
-        return SelfieSettingsSmuggleError(e)
-      }
-    }
   }
 }
 

--- a/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SelfieSettingsAPI.kt
+++ b/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SelfieSettingsAPI.kt
@@ -32,10 +32,11 @@ internal fun calcMode(): Mode {
 }
 
 /**
- * If you create a class named `SelfieSettings` in the package `selfie`, it must extend this class,
- * and you can override the methods below to customize various behaviors of selfie. You can also put
- * the settings class somewhere else if you set the `selfie.settings` system property to the fully
- * qualified name of the class you want selfie to use.
+ * To change the default settings, you must pass an instance of this class to the [SelfieExtension]
+ * in its constructor. The magic class
+ * [`selfie.SelfieSettings`](https://kdoc.selfie.dev/selfie-runner-junit5/com.diffplug.selfie.junit5/-selfie-settings-a-p-i/)
+ * that `selfie-runner-junit5` uses does not work with the multiplatform in `selfie-runner-kotest`
+ * - you have to pass the settings explicitly.
  */
 open class SelfieSettingsAPI {
   /**

--- a/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SnapshotSystemKotest.kt
+++ b/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SnapshotSystemKotest.kt
@@ -33,13 +33,11 @@ import com.diffplug.selfie.guts.SourceFile
 import com.diffplug.selfie.guts.TypedPath
 import com.diffplug.selfie.guts.WithinTestGC
 import com.diffplug.selfie.guts.atomic
-import kotlin.jvm.JvmStatic
 
-internal object SnapshotSystemKotest : SnapshotSystem {
-  @JvmStatic fun initStorage(): SnapshotSystem = this
+internal class SnapshotSystemKotest(settings: SelfieSettingsAPI) : SnapshotSystem {
   override val fs = FSOkio
   override val mode = calcMode()
-  override val layout = SnapshotFileLayoutKotest(SelfieSettingsAPI.initialize(), fs)
+  override val layout = SnapshotFileLayoutKotest(settings, fs)
   private val commentTracker = CommentTracker()
   private val inlineWriteTracker = InlineWriteTracker()
   private val progressPerFile = atomic(ArrayMap.empty<String, SnapshotFileProgress>())

--- a/jvm/selfie-runner-kotest/src/jsMain/kotlin/com/diffplug/selfie/kotest/SelfieSettingsAPI.js.kt
+++ b/jvm/selfie-runner-kotest/src/jsMain/kotlin/com/diffplug/selfie/kotest/SelfieSettingsAPI.js.kt
@@ -18,5 +18,3 @@ package com.diffplug.selfie.kotest
 internal actual fun readUserDir(): String = TODO()
 
 internal actual fun readEnvironmentVariable(name: String): String? = TODO()
-
-internal actual fun instantiateSettingsAt(name: String): SelfieSettingsAPI = TODO()

--- a/jvm/selfie-runner-kotest/src/jvmMain/kotlin/com/diffplug/selfie/kotest/SelfieSettingsAPI.jvm.kt
+++ b/jvm/selfie-runner-kotest/src/jvmMain/kotlin/com/diffplug/selfie/kotest/SelfieSettingsAPI.jvm.kt
@@ -18,18 +18,3 @@ package com.diffplug.selfie.kotest
 internal actual fun readUserDir(): String = System.getProperty("user.dir")
 
 internal actual fun readEnvironmentVariable(name: String): String? = System.getenv(name)
-
-internal actual fun instantiateSettingsAt(name: String): SelfieSettingsAPI {
-  val clazz =
-      try {
-        Class.forName(name)
-      } catch (e: ClassNotFoundException) {
-        throw e
-      }
-  try {
-    return clazz.getDeclaredConstructor().newInstance() as SelfieSettingsAPI
-  } catch (e: InstantiationException) {
-    throw AssertionError(
-        "Unable to instantiate ${clazz.name}, is it abstract? Does it require arguments?", e)
-  }
-}

--- a/selfie.dev/src/pages/jvm/kotest.mdx
+++ b/selfie.dev/src/pages/jvm/kotest.mdx
@@ -6,9 +6,18 @@ export const imageUrl = "https://selfie.dev/kotest.webp";
 
 <DocsImage imgAbsoluteUrl={imageUrl} />
 
-## Using Selfie with Kotest
+## Using Selfie with Kotest tldr
 
-Everything in the regular JVM [get started](./get-started) applies to Kotest as well. This page covers additional features which are specific to Kotest.
+- follow the regular JVM [get started](./get-started) instructions
+- add `SelfieExtension(projectConfig)` to your `AbstractProjectConfig`
+- make the following swap:
+  ```diff
+  -import com.diffplug.selfie.Selfie.expectSelfie
+  +import com.diffplug.selfie.coroutines.expectSelfie
+  ```
+And you're good to go!
+
+### Detailed setup
 
 Selfie has two artifacts which can run Kotest tests.
 


### PR DESCRIPTION
Settings discoverability is tough to do in a multiplatform way. Since `Kotest` has figured this out with their `AbstractProjectConfiguration` and our users have to explicitly add a `SelfieExtension` there anyway, we might as well tag along for the ride.