### PR TITLE
Kotest 5.4.0 is the oldest we support.

### DIFF
--- a/jvm/gradle.properties
+++ b/jvm/gradle.properties
@@ -9,4 +9,5 @@ ver_JUNIT_PIONEER=2.2.0
 ver_OKIO=3.8.0
 ver_KOTLIN_TEST=1.9.22
 ver_KOTLIN_SERIALIZATION=1.6.3
-ver_KOTEST=5.8.0
+# Kotest 5.4.0 is the oldest that we support
+ver_KOTEST=5.4.0


### PR DESCRIPTION
Possible to work with older versions, but would take some fiddling.