### PR TITLE
Make DiskStorage errors when running though Kotest lazy, so that we can use `toBe` anywhere.

### DIFF
--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The `coroutines` methods used to eagerly throw an exception if they were ever called from anywhere besides a Kotest method. Now they wait until `toMatchDisk()` is called, because they can work just fine anywhere if you use `toBe`. ([#247](https://github.com/diffplug/selfie/pull/247))
 
 ## [2.0.0] - 2024-02-21
 ### Added

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/coroutines/Coroutines.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/coroutines/Coroutines.kt
@@ -35,8 +35,7 @@ private suspend fun disk(): DiskStorage =
     coroutineContext[CoroutineDiskStorage]?.disk ?: DiskStorageError
 
 private const val WRONG_COROUTINE =
-    """
-No Kotest test is in progress on this coroutine.
+    """No Kotest test is in progress on this coroutine.
 If this is a Kotest test, make sure you added `SelfieExtension` to your `AbstractProjectConfig`:
   +class MyProjectConfig : AbstractProjectConfig() {
   +  override fun extensions() = listOf(SelfieExtension(this))
@@ -44,8 +43,7 @@ If this is a Kotest test, make sure you added `SelfieExtension` to your `Abstrac
 If this is a JUnit test, make the following change:
   -import com.diffplug.selfie.coroutines.expectSelfie
   +import com.diffplug.selfie.Selfie.expectSelfie
-For more info https://selfie.dev/jvm/kotest#selfie-and-coroutines
-"""
+For more info https://selfie.dev/jvm/kotest#selfie-and-coroutines"""
 
 private object DiskStorageError : DiskStorage {
   override fun readDisk(sub: String, call: CallStack) = throw IllegalStateException(WRONG_COROUTINE)


### PR DESCRIPTION
We only need `DiskStorage` for `toMatchDisk`, so we should be lazy about the error in case the user decides to go with `toBe`. This lets us do:

```kotlin
companion object {
  val someString = runBlocking {
    cacheSelfie { llmFunctionCall() }.toBe_TODO()
  }
}
```