### PR TITLE
LiteralString and LiteralStringTest

### DIFF
--- a/python/selfie-lib/selfie_lib/Literals.py
+++ b/python/selfie-lib/selfie_lib/Literals.py
@@ -136,7 +136,7 @@ class LiteralString(LiteralFormat[str]):
 
         def protect_trailing_whitespace(line):
             if line.endswith(" "):
-                return line[:-1] + "\\s"
+                return line[:-1] + "\x20"
             elif line.endswith("\t"):
                 return line[:-1] + "\\t"
             else:
@@ -145,28 +145,11 @@ class LiteralString(LiteralFormat[str]):
         lines = escape_triple_quotes.splitlines()
         protect_whitespace = "\n".join(
             escape_leading_whitespace.escape_line(
-                protect_trailing_whitespace(line), "\\s", "\\t"
+                protect_trailing_whitespace(line), "\x20", "\\t"
             )
             for line in lines
         )
 
-        common_prefix = min(
-            (line.lstrip() for line in protect_whitespace.splitlines() if line.strip()),
-            default="",
-        )
-        if common_prefix:
-            lines = protect_whitespace.splitlines()
-            last = lines[-1]
-            protect_whitespace = "\n".join(
-                f"\\s{line[1:]}"
-                if line.startswith(" ")
-                else f"\\t{line[1:]}"
-                if line.startswith("\t")
-                else line
-                if line != last
-                else (f"\\s{line[1:]}" if line.startswith(" ") else f"\\t{line[1:]}")
-                for line in lines
-            )
         return f"{TRIPLE_QUOTE}\n{protect_whitespace}{TRIPLE_QUOTE}"
 
     _char_literal_pattern = re.compile(r"""\{'(\\?.)'\}""")

--- a/python/selfie-lib/selfie_lib/Literals.py
+++ b/python/selfie-lib/selfie_lib/Literals.py
@@ -142,7 +142,7 @@ class LiteralString(LiteralFormat[str]):
 
         def protect_trailing_whitespace(line):
             if line.endswith(" "):
-                return line[:-1] + "\u0020"
+                return line[:-1] + "\\u0020"
             elif line.endswith("\t"):
                 return line[:-1] + "\\t"
             else:
@@ -151,7 +151,7 @@ class LiteralString(LiteralFormat[str]):
         lines = escape_triple_quotes.splitlines()
         protect_whitespace = "\n".join(
             escape_leading_whitespace.escape_line(
-                protect_trailing_whitespace(line), "\u0020", "\\t"
+                protect_trailing_whitespace(line), "\\u0020", "\\t"
             )
             for line in lines
         )

--- a/python/selfie-lib/selfie_lib/Literals.py
+++ b/python/selfie-lib/selfie_lib/Literals.py
@@ -79,20 +79,26 @@ class LiteralString(LiteralFormat[str]):
     def encode(
         self, value: str, language: Language, encoding_policy: EscapeLeadingWhitespace
     ) -> str:
-        if "/n" not in value:
-            if language == Language.PYTHON:
+        if language == Language.PYTHON:
+            if "/n" not in value:
                 return self._encodeSinglePython(value)
-        else:
-            if language == Language.PYTHON:
+            else:
                 return self.encodeMultiPython(value, encoding_policy)
+        else:
+            raise NotImplementedError(
+                "Encoding for language {} is not implemented.".format(language)
+            )
 
     def parse(self, string: str, language: Language) -> str:
-        if not string.startswith(TRIPLE_QUOTE):
-            if language == Language.PYTHON:
+        if language == Language.PYTHON:
+            if not string.startswith(TRIPLE_QUOTE):
                 return self._parseSinglePython(string)
-        else:
-            if language == Language.PYTHON:
+            else:
                 return self.parseMultiPython(string)
+        else:
+            raise NotImplementedError(
+                "Encoding for language {} is not implemented.".format(language)
+            )
 
     def _encodeSinglePython(self, value: str) -> str:
         source = io.StringIO()
@@ -136,7 +142,7 @@ class LiteralString(LiteralFormat[str]):
 
         def protect_trailing_whitespace(line):
             if line.endswith(" "):
-                return line[:-1] + "\x20"
+                return line[:-1] + "\u0020"
             elif line.endswith("\t"):
                 return line[:-1] + "\\t"
             else:
@@ -145,7 +151,7 @@ class LiteralString(LiteralFormat[str]):
         lines = escape_triple_quotes.splitlines()
         protect_whitespace = "\n".join(
             escape_leading_whitespace.escape_line(
-                protect_trailing_whitespace(line), "\x20", "\\t"
+                protect_trailing_whitespace(line), "\u0020", "\\t"
             )
             for line in lines
         )

--- a/python/selfie-lib/tests/LiteralString_test.py
+++ b/python/selfie-lib/tests/LiteralString_test.py
@@ -32,7 +32,7 @@ class TestLiteralString:
             ("\\", "'''\n\\\\'''"),
             (
                 "  leading\ntrailing  ",
-                "'''\n" + "\x20 leading\n" + "trailing \x20'''",
+                "'''\n" + "\u0020 leading\n" + "trailing \u0020'''",
             ),
         ],
     )

--- a/python/selfie-lib/tests/LiteralString_test.py
+++ b/python/selfie-lib/tests/LiteralString_test.py
@@ -23,8 +23,6 @@ class TestLiteralString:
         actual = literal_string._encodeSinglePython(value)
         assert actual == expected.replace("`", '"')
 
-    # Failing due to EscapeLeadingWhitespace always being NEVER
-    # and not an Always option like in the original test case
     @pytest.mark.parametrize(
         "value, expected",
         [
@@ -32,7 +30,7 @@ class TestLiteralString:
             ("\\", "'''\n\\\\'''"),
             (
                 "  leading\ntrailing  ",
-                "'''\n" + "\u0020 leading\n" + "trailing \u0020'''",
+                "'''\n" + "  leading\n" + "trailing \\u0020'''",
             ),
         ],
     )

--- a/python/selfie-lib/tests/LiteralString_test.py
+++ b/python/selfie-lib/tests/LiteralString_test.py
@@ -1,0 +1,62 @@
+import pytest
+from selfie_lib.Literals import LiteralString
+from selfie_lib.EscapeLeadingWhitespace import EscapeLeadingWhitespace
+
+
+class TestLiteralString:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [("1", '"1"'), ("\\", '"\\\\"'), ("1\n\tABC", '"1\\n\\tABC"')],
+    )
+    def test_encode_single_java(self, value, expected):
+        literal_string = LiteralString()
+        actual = literal_string._encodeSinglePython(value)
+        print(actual)
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [("1", "`1`"), ("\\", "`\\\\`"), ("1\n\tABC", "`1\\n\\tABC`")],
+    )
+    def test_encode_single_java_with_dollars(self, value, expected):
+        literal_string = LiteralString()
+        actual = literal_string._encodeSinglePython(value)
+        assert actual == expected.replace("`", '"')
+
+    # Failing due to EscapeLeadingWhitespace always being NEVER
+    # and not an Always option like in the original test case
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("1", "'''\n1'''"),
+            ("\\", "'''\n\\\\'''"),
+            ("  leading\ntrailing  ", "'''\n" + "\\s leading\n" + "trailing \\s'''"),
+        ],
+    )
+    def test_encode_multi_java(self, value, expected):
+        literal_string = LiteralString()
+        actual = literal_string.encodeMultiPython(value, EscapeLeadingWhitespace.NEVER)
+        assert actual == expected.replace("'", '"')
+
+    @pytest.mark.parametrize(
+        "value, expected", [("1", "1"), ("\\\\", "\\"), ("1\\n\\tABC", "1\n\tABC")]
+    )
+    def test_parse_single_java(self, value, expected):
+        literal_string = LiteralString()
+        actual = literal_string._parseSinglePython(f'"{value.replace("'", "\"")}"')
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("\n123\nabc", "123\nabc"),
+            ("\n  123\n  abc", "123\nabc"),
+            ("\n  123  \n  abc\t", "123\nabc"),
+            ("\n  123  \n  abc\t", "123\nabc"),
+            ("\n  123  \\s\n  abc\t\\s", "123   \nabc\t "),
+        ],
+    )
+    def test_parse_multi_java(self, value, expected):
+        literal_string = LiteralString()
+        actual = literal_string.parseMultiPython(f'"""{value.replace("'", "\"")}"""')
+        assert actual == expected

--- a/python/selfie-lib/tests/LiteralString_test.py
+++ b/python/selfie-lib/tests/LiteralString_test.py
@@ -8,7 +8,7 @@ class TestLiteralString:
         "value, expected",
         [("1", '"1"'), ("\\", '"\\\\"'), ("1\n\tABC", '"1\\n\\tABC"')],
     )
-    def test_encode_single_java(self, value, expected):
+    def test_encode_single(self, value, expected):
         literal_string = LiteralString()
         actual = literal_string._encodeSinglePython(value)
         print(actual)
@@ -18,7 +18,7 @@ class TestLiteralString:
         "value, expected",
         [("1", "`1`"), ("\\", "`\\\\`"), ("1\n\tABC", "`1\\n\\tABC`")],
     )
-    def test_encode_single_java_with_dollars(self, value, expected):
+    def test_encode_single_with_dollars(self, value, expected):
         literal_string = LiteralString()
         actual = literal_string._encodeSinglePython(value)
         assert actual == expected.replace("`", '"')
@@ -30,10 +30,13 @@ class TestLiteralString:
         [
             ("1", "'''\n1'''"),
             ("\\", "'''\n\\\\'''"),
-            ("  leading\ntrailing  ", "'''\n" + "\\s leading\n" + "trailing \\s'''"),
+            (
+                "  leading\ntrailing  ",
+                "'''\n" + "\x20 leading\n" + "trailing \x20'''",
+            ),
         ],
     )
-    def test_encode_multi_java(self, value, expected):
+    def test_encode_multi(self, value, expected):
         literal_string = LiteralString()
         actual = literal_string.encodeMultiPython(value, EscapeLeadingWhitespace.NEVER)
         assert actual == expected.replace("'", '"')
@@ -41,7 +44,7 @@ class TestLiteralString:
     @pytest.mark.parametrize(
         "value, expected", [("1", "1"), ("\\\\", "\\"), ("1\\n\\tABC", "1\n\tABC")]
     )
-    def test_parse_single_java(self, value, expected):
+    def test_parse_single(self, value, expected):
         literal_string = LiteralString()
         actual = literal_string._parseSinglePython(f'"{value.replace("'", "\"")}"')
         assert actual == expected
@@ -56,7 +59,7 @@ class TestLiteralString:
             ("\n  123  \\s\n  abc\t\\s", "123   \nabc\t "),
         ],
     )
-    def test_parse_multi_java(self, value, expected):
+    def test_parse_multi(self, value, expected):
         literal_string = LiteralString()
         actual = literal_string.parseMultiPython(f'"""{value.replace("'", "\"")}"""')
         assert actual == expected


### PR DESCRIPTION
- Fixed the issue for "\\u0020" in Literals.py and for LiteralString_test.py. 
- For the third test in test_encode_multi, We have escape_leading_whitespace set to never so I took the leading case out. 