### PR TITLE
Fix the python landing page

### DIFF
--- a/selfie.dev/src/components/ButtonList.tsx
+++ b/selfie.dev/src/components/ButtonList.tsx
@@ -39,7 +39,7 @@ export function ButtonList() {
           js
         </Button>
       </Link>
-      <Link href="/other-platforms">
+      <Link href="/py">
         <Button
           className={
             selectedLanguage === "py" ? pressedClasses : unPressedClasses
@@ -48,7 +48,7 @@ export function ButtonList() {
           py
         </Button>
       </Link>
-      <Link href="/other-platforms">
+      <Link href="/py">
         <Button
           className={
             selectedLanguage === "other-platforms"

--- a/selfie.dev/src/components/IntroText.tsx
+++ b/selfie.dev/src/components/IntroText.tsx
@@ -2,10 +2,16 @@ import clsx from "clsx";
 import slugify from "@sindresorhus/slugify";
 import { Button } from "./Button";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { getPathParts } from "@/lib/languageFromPath";
 
-const THE_CONTEXT_WINDOW = "https://thecontextwindow.ai/p/temporarily-embarrassed-snapshots";
+const THE_CONTEXT_WINDOW =
+  "https://thecontextwindow.ai/p/temporarily-embarrassed-snapshots";
 
 export function IntroText() {
+  const router = useRouter();
+  const selectedLanguage = getPathParts(router.pathname).language;
+
   return (
     <div
       className={clsx([
@@ -35,7 +41,7 @@ export function IntroText() {
         <SectionLink title="literal" />, <SectionLink title="lensable" />
         <br /> and <SectionLink title="like a filesystem" />
       </p>
-      <Link href="/jvm/get-started">
+      <Link href={`/${selectedLanguage}/get-started`}>
         <Button
           className={clsx([
             "w-[154px]",
@@ -67,14 +73,25 @@ export function IntroText() {
       >
         <p>
           Snapshot testing is the <br />{" "}
-          <a href={THE_CONTEXT_WINDOW} className="text-blue hover:underline cursor-pointer">fastest and most precise</a>
+          <a
+            href={THE_CONTEXT_WINDOW}
+            className="text-blue hover:underline cursor-pointer"
+          >
+            fastest and most precise
+          </a>
           <br />
           mechanism to{" "}
-          <a href={THE_CONTEXT_WINDOW} className="text-red hover:underline cursor-pointer">
+          <a
+            href={THE_CONTEXT_WINDOW}
+            className="text-red hover:underline cursor-pointer"
+          >
             record <br /> and specify
           </a>{" "}
           the <br />
-          <a href={THE_CONTEXT_WINDOW} className="text-green hover:underline cursor-pointer">
+          <a
+            href={THE_CONTEXT_WINDOW}
+            className="text-green hover:underline cursor-pointer"
+          >
             behavior of your <br />
             system and its <br />
             components

--- a/selfie.dev/src/pages/py/index.mdx
+++ b/selfie.dev/src/pages/py/index.mdx
@@ -1,0 +1,164 @@
+import { FooterCTA } from "@/components/FooterCTA/FooterCTA";
+import { NavHeading } from "@/components/NavHeading";
+
+export const showHeroLinks = 'true';
+export const title = "Selfie JVM Snapshot Testing";
+export const description = "Zero-config inline and disk snapshots for Java, Kotlin, and more. Features garbage collection, filesystem-like APIs for snapshot data, and novel techniques for storytelling within test code.";
+
+<NavHeading text="literal" popout="/jvm/get-started#quickstart" />
+
+This is a reasonable way to test.
+
+```java
+@Test
+public void primesBelow100() {
+  Assertions.assertThat(primesBelow(100)).startsWith(2, 3, 5, 7).endsWith(89, 97);
+}
+```
+
+But oftentimes a more useful way to test is actually:
+
+```java
+@Test
+public void testMcTestFace() {
+  System.out.println(primesBelow(100));
+}
+```
+
+With literal snapshots, you can `println` directly into your testcode, combining the speed and freedom of `println` with the repeatability and collaborative spirit of conventional assertions.
+
+```java
+@Test
+public void primesBelow100() {
+  expectSelfie(primesBelow(100).toString()).toBe_TODO();
+}
+```
+
+When you run the test, selfie will automatically rewrite `_TODO()` into whatever it turned out to be.
+
+```java
+@Test
+public void primesBelow100() {
+  expectSelfie(primesBelow(100).toString())
+    .toBe("[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]");
+}
+```
+
+And from now on it's a proper assertion, but you didn't have to spend any time writing it. It's not only less work, but also more complete than the usual `.startsWith().endsWith()` rigamarole.
+
+<NavHeading text="like-a-filesystem" popout="/jvm/get-started#disk" />
+
+That `primesBelow(100)` snapshot above is almost too long. Something bigger, such as `primesBelow(10_000)` is definitely too big. To handle this, selfie lets you put your snapshots on disk.
+
+```java
+@Test
+public void gzipFavicon() {
+    expectSelfie(get("/favicon.ico", ContentEncoding.GZIP)).toMatchDisk();
+}
+
+@Test
+public void orderFlow() {
+  expectSelfie(get("/orders")).toMatchDisk("initial");
+  postOrder();
+  expectSelfie(get("/orders")).toMatchDisk("ordered");
+}
+```
+
+This will generate a snapshot file like so:
+
+```html
+╔═ gzipFavicon ═╗ base64 length 12 bytes
+Umlja1JvbGwuanBn
+╔═ orderFlow/initial ═╗
+<html><body>
+  <button>Submit order</button>
+</body></html>
+╔═ orderFlow/ordered ═╗
+<html><body>
+  <p>Thanks for your business!</p>
+  <details>
+    <summary>Order information</summary>
+    <p>Tracking #ABC123</p>
+  </details>
+</body></html>
+```
+
+Selfie's snapshot files `.ss` are simple to parse, just split them up on `\n╔═`. Escaping rules only come into play if the content you are escaping has lines that start with `╔`,  and you can always use `selfie-lib` as a parser if you want.
+
+You can treat your snapshot files as an output deliverable of your code, and use them as an input to other tooling.
+
+<NavHeading text="lensable" popout="/jvm/facets" />
+
+A problem with the snapshots we've shown so far is that they are one dimensional. What about headers and cookies? What about the content the user actually sees, without all the markup? What if we could do this? 
+
+```
+╔═ orderFlow/initial [md] ═╗
+Submit order
+╔═ orderFlow/ordered [md] ═╗
+Thanks for your business!</p>
+```
+
+Well, you can! Every snapshot has a *subject*, which is the main thing you are recording. And that subject can have any number of *facets*, which are named views of the subject from a different lens.
+
+```java
+var html = "<html>..."
+var snapshot = Snapshot.of(html).plusFacet("md", HtmlToMdParser.parse(html))
+expectSelfie(snapshot).toMatchDisk()
+```
+
+You can also use facets in combination with disk and inline literal snapshots to make your tests more like a story.
+
+```java
+@Test
+public void orderFlow() {
+  expectSelfie(get("/orders")).toMatchDisk("initial")
+    .facet("md").toBe("Submit order");
+  postOrder();
+  expectSelfie(get("/orders")).toMatchDisk("ordered")
+    .facet("md").toBe("Thanks for your business!");
+}
+```
+
+Selfie's faceting is built around [Camera](https://kdoc.selfie.dev/selfie-lib/com.diffplug.selfie/-camera/), [Lens](https://kdoc.selfie.dev/selfie-lib/com.diffplug.selfie/-lens/), and [Snapshot](https://kdoc.selfie.dev/selfie-lib/com.diffplug.selfie/-snapshot/), whose API is roughly:
+
+```java
+final class Snapshot {
+  final SnapshotValue subject;
+  final ImmutableSortedMap<String, SnapshotValue> facets;
+}
+interface Lens {
+  Snapshot transform(Snapshot snapshot);
+}
+interface Camera<T> {
+  Snapshot snapshot(T subject);
+  default Camera<T> withLens(Lens lens) {
+    // returns a new Camera which applies the given lens to every snapshot
+  }
+}
+```
+
+See the [facets section](/jvm/facets) for more details on how you can use Selfie for snapshot testing with Java, Kotlin, or any JVM language.
+
+<NavHeading text="cacheable" popout="/jvm/cache" />
+
+Sometimes a test has a component which is slow, expensive, or non-deterministic. In cases like this, it can be useful to save the result of a previous execution of the API call, and use that as a mock for future tests.
+
+```java
+var client = ExpensiveAiService();
+var chatResponse = cacheSelfie(() -> {
+  return client.chat("What's your favorite number today?");
+}).toBe("Since it's March 14, my favorite number is π")
+// build other stuff with the chat response
+```
+
+You can cache simple strings, but you can also cache typed API objects, binary data, or anything else you can serialize to a string or a byte array.
+
+```java
+var imageBytes = cacheSelfieBinary(() -> {
+  return client.generateImage("A robot making a self portrait");
+}).toBeFile("selfie.png")
+```
+
+For more information on how to use `cacheSelfie`, see the [cache example](/jvm/cache).
+
+<FooterCTA />

--- a/selfie.dev/src/pages/py/index.mdx
+++ b/selfie.dev/src/pages/py/index.mdx
@@ -2,14 +2,14 @@ import { FooterCTA } from "@/components/FooterCTA/FooterCTA";
 import { NavHeading } from "@/components/NavHeading";
 
 export const showHeroLinks = 'true';
-export const title = "Selfie JVM Snapshot Testing";
-export const description = "Zero-config inline and disk snapshots for Java, Kotlin, and more. Features garbage collection, filesystem-like APIs for snapshot data, and novel techniques for storytelling within test code.";
+export const title = "Selfie Python Snapshot Testing";
+export const description = "Zero-config inline and disk snapshots for Python. Features garbage collection, filesystem-like APIs for snapshot data, and novel techniques for storytelling within test code.";
 
-<NavHeading text="literal" popout="/jvm/get-started#quickstart" />
+<NavHeading text="literal" popout="/py/get-started#quickstart" />
 
 This is a reasonable way to test.
 
-```java
+```python
 @Test
 public void primesBelow100() {
   Assertions.assertThat(primesBelow(100)).startsWith(2, 3, 5, 7).endsWith(89, 97);
@@ -18,7 +18,7 @@ public void primesBelow100() {
 
 But oftentimes a more useful way to test is actually:
 
-```java
+```python
 @Test
 public void testMcTestFace() {
   System.out.println(primesBelow(100));
@@ -27,7 +27,7 @@ public void testMcTestFace() {
 
 With literal snapshots, you can `println` directly into your testcode, combining the speed and freedom of `println` with the repeatability and collaborative spirit of conventional assertions.
 
-```java
+```python
 @Test
 public void primesBelow100() {
   expectSelfie(primesBelow(100).toString()).toBe_TODO();
@@ -36,7 +36,7 @@ public void primesBelow100() {
 
 When you run the test, selfie will automatically rewrite `_TODO()` into whatever it turned out to be.
 
-```java
+```python
 @Test
 public void primesBelow100() {
   expectSelfie(primesBelow(100).toString())
@@ -46,11 +46,11 @@ public void primesBelow100() {
 
 And from now on it's a proper assertion, but you didn't have to spend any time writing it. It's not only less work, but also more complete than the usual `.startsWith().endsWith()` rigamarole.
 
-<NavHeading text="like-a-filesystem" popout="/jvm/get-started#disk" />
+<NavHeading text="like-a-filesystem" popout="/py/get-started#disk" />
 
 That `primesBelow(100)` snapshot above is almost too long. Something bigger, such as `primesBelow(10_000)` is definitely too big. To handle this, selfie lets you put your snapshots on disk.
 
-```java
+```python
 @Test
 public void gzipFavicon() {
     expectSelfie(get("/favicon.ico", ContentEncoding.GZIP)).toMatchDisk();
@@ -87,7 +87,7 @@ Selfie's snapshot files `.ss` are simple to parse, just split them up on `\nâ•”â
 
 You can treat your snapshot files as an output deliverable of your code, and use them as an input to other tooling.
 
-<NavHeading text="lensable" popout="/jvm/facets" />
+<NavHeading text="lensable" popout="/py/facets" />
 
 A problem with the snapshots we've shown so far is that they are one dimensional. What about headers and cookies? What about the content the user actually sees, without all the markup? What if we could do this? 
 
@@ -100,7 +100,7 @@ Thanks for your business!</p>
 
 Well, you can! Every snapshot has a *subject*, which is the main thing you are recording. And that subject can have any number of *facets*, which are named views of the subject from a different lens.
 
-```java
+```python
 var html = "<html>..."
 var snapshot = Snapshot.of(html).plusFacet("md", HtmlToMdParser.parse(html))
 expectSelfie(snapshot).toMatchDisk()
@@ -108,7 +108,7 @@ expectSelfie(snapshot).toMatchDisk()
 
 You can also use facets in combination with disk and inline literal snapshots to make your tests more like a story.
 
-```java
+```python
 @Test
 public void orderFlow() {
   expectSelfie(get("/orders")).toMatchDisk("initial")
@@ -121,7 +121,7 @@ public void orderFlow() {
 
 Selfie's faceting is built around [Camera](https://kdoc.selfie.dev/selfie-lib/com.diffplug.selfie/-camera/), [Lens](https://kdoc.selfie.dev/selfie-lib/com.diffplug.selfie/-lens/), and [Snapshot](https://kdoc.selfie.dev/selfie-lib/com.diffplug.selfie/-snapshot/), whose API is roughly:
 
-```java
+```python
 final class Snapshot {
   final SnapshotValue subject;
   final ImmutableSortedMap<String, SnapshotValue> facets;
@@ -137,13 +137,13 @@ interface Camera<T> {
 }
 ```
 
-See the [facets section](/jvm/facets) for more details on how you can use Selfie for snapshot testing with Java, Kotlin, or any JVM language.
+See the [facets section](/py/facets) for more details on how you can use Selfie for snapshot testing with Java, Kotlin, or any JVM language.
 
-<NavHeading text="cacheable" popout="/jvm/cache" />
+<NavHeading text="cacheable" popout="/py/cache" />
 
 Sometimes a test has a component which is slow, expensive, or non-deterministic. In cases like this, it can be useful to save the result of a previous execution of the API call, and use that as a mock for future tests.
 
-```java
+```python
 var client = ExpensiveAiService();
 var chatResponse = cacheSelfie(() -> {
   return client.chat("What's your favorite number today?");
@@ -153,12 +153,12 @@ var chatResponse = cacheSelfie(() -> {
 
 You can cache simple strings, but you can also cache typed API objects, binary data, or anything else you can serialize to a string or a byte array.
 
-```java
+```python
 var imageBytes = cacheSelfieBinary(() -> {
   return client.generateImage("A robot making a self portrait");
 }).toBeFile("selfie.png")
 ```
 
-For more information on how to use `cacheSelfie`, see the [cache example](/jvm/cache).
+For more information on how to use `cacheSelfie`, see the [cache example](/py/cache).
 
 <FooterCTA />


### PR DESCRIPTION
- At `selfie.dev` right now, if you click "py" on the homepage, it takes you to a github issue
- In this PR, we add the "python" landing page. It works locally.
- But when we go to selfie.dev, clicking "py" will still take us to GitHub instead of the python landing page, because of this line
  - https://github.com/diffplug/selfie/blob/7b31cc6f08f313d563124cccb4d49933a870bd68/selfie.dev/public/_redirects#L4

For now, this is on purpose. "selfie.dev" has the "real" docs live, but we are hiding the landing page until we are ready.