### PR TITLE
Do not remove stale snapshot files when readonly is true

### DIFF
--- a/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotSystemJUnit5.kt
+++ b/jvm/selfie-runner-junit5/src/main/kotlin/com/diffplug/selfie/junit5/SnapshotSystemJUnit5.kt
@@ -111,14 +111,14 @@ internal object SnapshotSystemJUnit5 : SnapshotSystem {
       if (inlineWriteTracker.hasWrites()) {
         inlineWriteTracker.persistWrites(layout)
       }
-    }
-    for (stale in findStaleSnapshotFiles(layout)) {
-      val staleFile = layout.snapshotPathForClass(stale)
-      if (snapshotsFilesWrittenToDisk.contains(staleFile)) {
-        throw AssertionError(
-            "Selfie wrote a snapshot and then marked it stale for deletion in the same run: $staleFile\nSelfie will delete this snapshot on the next run, which is bad! Why is Selfie marking this snapshot as stale?")
-      } else {
-        deleteFileAndParentDirIfEmpty(staleFile)
+      for (stale in findStaleSnapshotFiles(layout)) {
+        val staleFile = layout.snapshotPathForClass(stale)
+        if (snapshotsFilesWrittenToDisk.contains(staleFile)) {
+          throw AssertionError(
+              "Selfie wrote a snapshot and then marked it stale for deletion in the same run: $staleFile\nSelfie will delete this snapshot on the next run, which is bad! Why is Selfie marking this snapshot as stale?")
+        } else {
+          deleteFileAndParentDirIfEmpty(staleFile)
+        }
       }
     }
   }

--- a/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SnapshotSystemKotest.kt
+++ b/jvm/selfie-runner-kotest/src/commonMain/kotlin/com/diffplug/selfie/kotest/SnapshotSystemKotest.kt
@@ -95,14 +95,14 @@ internal class SnapshotSystemKotest(settings: SelfieSettingsAPI) : SnapshotSyste
       if (inlineWriteTracker.hasWrites()) {
         inlineWriteTracker.persistWrites(layout)
       }
-    }
-    for (stale in findStaleSnapshotFiles(layout)) {
-      val staleFile = layout.snapshotPathForClassOrFilename(stale)
-      if (snapshotsFilesWrittenToDisk.contains(staleFile)) {
-        throw AssertionError(
-            "Selfie wrote a snapshot and then marked it stale for deletion in the same run: $staleFile\nSelfie will delete this snapshot on the next run, which is bad! Why is Selfie marking this snapshot as stale?")
-      } else {
-        deleteFileAndParentDirIfEmpty(staleFile)
+      for (stale in findStaleSnapshotFiles(layout)) {
+        val staleFile = layout.snapshotPathForClassOrFilename(stale)
+        if (snapshotsFilesWrittenToDisk.contains(staleFile)) {
+          throw AssertionError(
+              "Selfie wrote a snapshot and then marked it stale for deletion in the same run: $staleFile\nSelfie will delete this snapshot on the next run, which is bad! Why is Selfie marking this snapshot as stale?")
+        } else {
+          deleteFileAndParentDirIfEmpty(staleFile)
+        }
       }
     }
   }


### PR DESCRIPTION
I ran into an issue where my CI system was deleting my snapshot files. It seems like the readonly flag should apply to any modification selfie might try to make.

I was unable to find any tests that exercise this code so no tests were added.