### PR TITLE
Sort imports

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: poetry run pyright
         working-directory: python/selfie-lib
       - name: selfie-lib - ruff
-        run: poetry run ruff format --check
+        run: poetry run ruff format --check && poetry run ruff check
         working-directory: python/selfie-lib
       - name: pytest-selfie - poetry install
         run: poetry install
@@ -42,7 +42,7 @@ jobs:
         run: poetry run pyright
         working-directory: python/pytest-selfie
       - name: pytest-selfie - ruff
-        run: poetry run ruff format --check
+        run: poetry run ruff format --check && poetry run ruff check
         working-directory: python/pytest-selfie
       - name: example-pytest-selfie - poetry install
         run: poetry install
@@ -53,5 +53,5 @@ jobs:
       #   run: poetry run pyright
       #   working-directory: python/example-pytest-selfie
       - name: example-pytest-selfie - ruff
-        run: poetry run ruff format --check
+        run: poetry run ruff format --check && poetry run ruff check
         working-directory: python/example-pytest-selfie

--- a/python/example-pytest-selfie/pyproject.toml
+++ b/python/example-pytest-selfie/pyproject.toml
@@ -19,3 +19,6 @@ pytest-selfie = { path = "../pytest-selfie", develop = true }
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+lint.extend-select = ["I"]

--- a/python/example-pytest-selfie/tests/cache_selfie_test.py
+++ b/python/example-pytest-selfie/tests/cache_selfie_test.py
@@ -1,5 +1,6 @@
-from selfie_lib.Selfie import cache_selfie_string
 import random
+
+from selfie_lib.Selfie import cache_selfie_string
 
 
 def test_cache_selfie():

--- a/python/example-pytest-selfie/tests/simple_inline_test.py
+++ b/python/example-pytest-selfie/tests/simple_inline_test.py
@@ -1,6 +1,5 @@
 from selfie_lib.Selfie import expect_selfie
 
-
 # def test_read_pass():
 #     expect_selfie("A").to_be("A")
 

--- a/python/example-pytest-selfie/tests/to_be_file_test.py
+++ b/python/example-pytest-selfie/tests/to_be_file_test.py
@@ -1,13 +1,13 @@
-from selfie_lib.WriteTracker import (
-    ToBeFileWriteTracker,
-    ToBeFileLazyBytes,
-    recordCall,
-    TypedPath,
-    SnapshotFileLayout,
-)
-from pytest_selfie import FSImplementation
-from pathlib import Path
 import os
+from pathlib import Path
+
+from pytest_selfie import FSImplementation
+from selfie_lib.WriteTracker import (
+    SnapshotFileLayout,
+    ToBeFileWriteTracker,
+    TypedPath,
+    recordCall,
+)
 
 
 def test_to_be_file():

--- a/python/pytest-selfie/pyproject.toml
+++ b/python/pytest-selfie/pyproject.toml
@@ -23,3 +23,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.plugins.pytest11]
 pytest_selfie = "pytest_selfie.plugin"
+
+[tool.ruff]
+lint.extend-select = ["I"]

--- a/python/pytest-selfie/pytest_selfie/SelfieSettingsAPI.py
+++ b/python/pytest-selfie/pytest_selfie/SelfieSettingsAPI.py
@@ -1,9 +1,9 @@
 import os
 from pathlib import Path
-import re
 from typing import Optional
-from selfie_lib import Mode
+
 import pytest
+from selfie_lib import Mode
 
 
 class SelfieSettingsAPI:

--- a/python/pytest-selfie/pytest_selfie/__init__.py
+++ b/python/pytest-selfie/pytest_selfie/__init__.py
@@ -1,2 +1,2 @@
-from .SelfieSettingsAPI import SelfieSettingsAPI as SelfieSettingsAPI
 from .plugin import FSImplementation as FSImplementation
+from .SelfieSettingsAPI import SelfieSettingsAPI as SelfieSettingsAPI

--- a/python/pytest-selfie/pytest_selfie/plugin.py
+++ b/python/pytest-selfie/pytest_selfie/plugin.py
@@ -1,21 +1,17 @@
-from cgi import test
 import os
+from cgi import test
 from collections import defaultdict
-from typing import ByteString, DefaultDict, List, Optional, Iterator
+from typing import ByteString, DefaultDict, Iterator, List, Optional
 
-from selfie_lib.Atomic import AtomicReference
-from selfie_lib.WriteTracker import ToBeFileWriteTracker
-from .SelfieSettingsAPI import SelfieSettingsAPI
+import pytest
 from selfie_lib import (
-    _clearSelfieSystem,
-    _initSelfieSystem,
+    FS,
     ArrayMap,
     ArraySet,
     CallStack,
     CommentTracker,
     DiskStorage,
     DiskWriteTracker,
-    FS,
     InlineWriteTracker,
     LiteralValue,
     Mode,
@@ -27,8 +23,13 @@ from selfie_lib import (
     SourceFile,
     TypedPath,
     WithinTestGC,
+    _clearSelfieSystem,
+    _initSelfieSystem,
 )
-import pytest
+from selfie_lib.Atomic import AtomicReference
+from selfie_lib.WriteTracker import ToBeFileWriteTracker
+
+from .SelfieSettingsAPI import SelfieSettingsAPI
 
 
 class FSImplementation(FS):

--- a/python/pytest-selfie/pytest_selfie/replace_todo.py
+++ b/python/pytest-selfie/pytest_selfie/replace_todo.py
@@ -1,9 +1,10 @@
 import re
 from pathlib import Path
+
 from selfie_lib import (
     CommentTracker,
-    recordCall,
     TypedPath,
+    recordCall,
 )
 
 

--- a/python/selfie-lib/pyproject.toml
+++ b/python/selfie-lib/pyproject.toml
@@ -17,3 +17,6 @@ pytest = "^8.0.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+lint.extend-select = ["I"]

--- a/python/selfie-lib/selfie_lib/ArrayMap.py
+++ b/python/selfie-lib/selfie_lib/ArrayMap.py
@@ -1,5 +1,4 @@
 from collections.abc import Set, Iterator, Mapping, ItemsView
-import re
 from typing import List, Tuple, TypeVar, Union, Any
 from abc import abstractmethod, ABC
 

--- a/python/selfie-lib/selfie_lib/ArrayMap.py
+++ b/python/selfie-lib/selfie_lib/ArrayMap.py
@@ -1,6 +1,6 @@
-from collections.abc import Set, Iterator, Mapping, ItemsView
-from typing import List, Tuple, TypeVar, Union, Any
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
+from collections.abc import ItemsView, Iterator, Mapping, Set
+from typing import Any, List, Tuple, TypeVar, Union
 
 T = TypeVar("T")
 V = TypeVar("V")

--- a/python/selfie-lib/selfie_lib/Atomic.py
+++ b/python/selfie-lib/selfie_lib/Atomic.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Callable
 
 
 class AtomicReference[T]:

--- a/python/selfie-lib/selfie_lib/CacheSelfie.py
+++ b/python/selfie-lib/selfie_lib/CacheSelfie.py
@@ -1,10 +1,11 @@
-from typing import Generic, TypeVar, Optional, Any
-from .WriteTracker import recordCall
-from .Snapshot import Snapshot
-from .Literals import LiteralValue, LiteralString, TodoStub
-from .SnapshotSystem import DiskStorage
-from .RoundTrip import Roundtrip
 import base64
+from typing import Any, Generic, Optional, TypeVar
+
+from .Literals import LiteralString, LiteralValue, TodoStub
+from .RoundTrip import Roundtrip
+from .Snapshot import Snapshot
+from .SnapshotSystem import DiskStorage
+from .WriteTracker import recordCall
 
 T = TypeVar("T")
 

--- a/python/selfie-lib/selfie_lib/CommentTracker.py
+++ b/python/selfie-lib/selfie_lib/CommentTracker.py
@@ -1,5 +1,4 @@
-from typing import Dict, Iterable, Tuple, Sequence, TypeVar, Callable
-from abc import ABC, abstractmethod
+from typing import Dict, Iterable, Tuple
 from enum import Enum, auto
 import threading
 

--- a/python/selfie-lib/selfie_lib/CommentTracker.py
+++ b/python/selfie-lib/selfie_lib/CommentTracker.py
@@ -1,6 +1,6 @@
-from typing import Dict, Iterable, Tuple
-from enum import Enum, auto
 import threading
+from enum import Enum, auto
+from typing import Dict, Iterable, Tuple
 
 from .Slice import Slice
 from .TypedPath import TypedPath

--- a/python/selfie-lib/selfie_lib/FS.py
+++ b/python/selfie-lib/selfie_lib/FS.py
@@ -1,8 +1,8 @@
-from selfie_lib.TypedPath import TypedPath
-from pathlib import Path
-
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Callable, Iterator
+
+from selfie_lib.TypedPath import TypedPath
 
 
 class FS(ABC):

--- a/python/selfie-lib/selfie_lib/FS.py
+++ b/python/selfie-lib/selfie_lib/FS.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from abc import ABC, abstractmethod
 from typing import Callable, Iterator
-from itertools import chain
 
 
 class FS(ABC):

--- a/python/selfie-lib/selfie_lib/Literals.py
+++ b/python/selfie-lib/selfie_lib/Literals.py
@@ -1,4 +1,3 @@
-from calendar import c
 from enum import Enum, auto
 from typing import Any, Protocol, TypeVar
 from abc import abstractmethod

--- a/python/selfie-lib/selfie_lib/Literals.py
+++ b/python/selfie-lib/selfie_lib/Literals.py
@@ -1,10 +1,10 @@
-from enum import Enum, auto
-from typing import Any, Protocol, TypeVar
-from abc import abstractmethod
-
-from .EscapeLeadingWhitespace import EscapeLeadingWhitespace
 import io
 import re
+from abc import abstractmethod
+from enum import Enum, auto
+from typing import Any, Protocol, TypeVar
+
+from .EscapeLeadingWhitespace import EscapeLeadingWhitespace
 
 T = TypeVar("T")
 

--- a/python/selfie-lib/selfie_lib/RoundTrip.py
+++ b/python/selfie-lib/selfie_lib/RoundTrip.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Generic, Any
+from typing import Any, Generic, TypeVar
 
 # Define generic type variables
 T = TypeVar("T")

--- a/python/selfie-lib/selfie_lib/Selfie.py
+++ b/python/selfie-lib/selfie_lib/Selfie.py
@@ -1,9 +1,10 @@
-from typing import Any, TypeVar, Optional, Protocol, Union, overload
-from .SelfieImplementations import ReprSelfie, StringSelfie
-from .SnapshotSystem import _selfieSystem
-from .Snapshot import Snapshot
+from typing import Any, Optional, Protocol, TypeVar, Union, overload
+
 from .CacheSelfie import CacheSelfie
 from .RoundTrip import Roundtrip
+from .SelfieImplementations import ReprSelfie, StringSelfie
+from .Snapshot import Snapshot
+from .SnapshotSystem import _selfieSystem
 
 # Declare T as covariant
 T = TypeVar("T", covariant=True)

--- a/python/selfie-lib/selfie_lib/SelfieImplementations.py
+++ b/python/selfie-lib/selfie_lib/SelfieImplementations.py
@@ -1,9 +1,8 @@
 import base64
+from abc import ABC, abstractmethod
+from itertools import chain
+from typing import Any, List, Optional
 
-from .Snapshot import Snapshot
-from .SnapshotFile import SnapshotFile
-from .SnapshotSystem import DiskStorage, SnapshotSystem, _selfieSystem, Mode
-from .WriteTracker import recordCall as recordCall
 from .Literals import (
     LiteralFormat,
     LiteralRepr,
@@ -11,11 +10,10 @@ from .Literals import (
     LiteralValue,
     TodoStub,
 )
-
-
-from abc import ABC, abstractmethod
-from typing import Any, List, Optional
-from itertools import chain
+from .Snapshot import Snapshot
+from .SnapshotFile import SnapshotFile
+from .SnapshotSystem import DiskStorage, Mode, SnapshotSystem, _selfieSystem
+from .WriteTracker import recordCall as recordCall
 
 
 class ReprSelfie[T]:

--- a/python/selfie-lib/selfie_lib/Slice.py
+++ b/python/selfie-lib/selfie_lib/Slice.py
@@ -1,6 +1,5 @@
-from typing import Optional
-from typing import Union
 from collections import Counter
+from typing import Optional, Union
 
 
 class Slice:

--- a/python/selfie-lib/selfie_lib/Snapshot.py
+++ b/python/selfie-lib/selfie_lib/Snapshot.py
@@ -1,6 +1,7 @@
-from typing import Union, Iterable, Dict
-from .SnapshotValue import SnapshotValue
+from typing import Dict, Iterable, Union
+
 from .ArrayMap import ArrayMap
+from .SnapshotValue import SnapshotValue
 
 
 class Snapshot:

--- a/python/selfie-lib/selfie_lib/Snapshot.py
+++ b/python/selfie-lib/selfie_lib/Snapshot.py
@@ -1,5 +1,5 @@
 from typing import Union, Iterable, Dict
-from .SnapshotValue import SnapshotValue, SnapshotValueBinary, SnapshotValueString
+from .SnapshotValue import SnapshotValue
 from .ArrayMap import ArrayMap
 
 

--- a/python/selfie-lib/selfie_lib/SnapshotFile.py
+++ b/python/selfie-lib/selfie_lib/SnapshotFile.py
@@ -1,11 +1,11 @@
 import base64
 from threading import Lock
-from typing import Tuple, List, Optional
+from typing import List, Optional, Tuple
 
+from .ArrayMap import ArrayMap
 from .Snapshot import Snapshot, SnapshotValue
 from .SnapshotReader import SnapshotReader
 from .SnapshotValueReader import SnapshotValueReader
-from .ArrayMap import ArrayMap
 
 
 class SnapshotFile:

--- a/python/selfie-lib/selfie_lib/SnapshotReader.py
+++ b/python/selfie-lib/selfie_lib/SnapshotReader.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 from .Snapshot import Snapshot
 from .SnapshotValueReader import SnapshotValueReader
 

--- a/python/selfie-lib/selfie_lib/SnapshotSystem.py
+++ b/python/selfie-lib/selfie_lib/SnapshotSystem.py
@@ -2,13 +2,12 @@ from abc import ABC, abstractmethod
 from enum import Enum, auto
 from typing import ByteString, Optional
 
+from .CommentTracker import CommentTracker
 from .FS import FS
-
 from .Literals import LiteralValue
 from .Snapshot import Snapshot
 from .TypedPath import TypedPath
 from .WriteTracker import CallStack, SnapshotFileLayout
-from .CommentTracker import CommentTracker
 
 
 class DiskStorage(ABC):

--- a/python/selfie-lib/selfie_lib/SnapshotSystem.py
+++ b/python/selfie-lib/selfie_lib/SnapshotSystem.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from enum import Enum, auto
-import glob
 from typing import ByteString, Optional
 
 from .FS import FS

--- a/python/selfie-lib/selfie_lib/SnapshotValue.py
+++ b/python/selfie-lib/selfie_lib/SnapshotValue.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Union, Type
+from typing import Union
 
 
 def unix_newlines(string: str) -> str:

--- a/python/selfie-lib/selfie_lib/SnapshotValueReader.py
+++ b/python/selfie-lib/selfie_lib/SnapshotValueReader.py
@@ -1,8 +1,9 @@
 import base64
 from typing import Callable, List, Optional
-from .PerCharacterEscaper import PerCharacterEscaper
-from .ParseException import ParseException
+
 from .LineReader import LineReader
+from .ParseException import ParseException
+from .PerCharacterEscaper import PerCharacterEscaper
 from .SnapshotValue import SnapshotValue
 
 

--- a/python/selfie-lib/selfie_lib/SourceFile.py
+++ b/python/selfie-lib/selfie_lib/SourceFile.py
@@ -1,7 +1,8 @@
-from .Slice import Slice
-from .Literals import Language, LiteralFormat, LiteralValue
-from .EscapeLeadingWhitespace import EscapeLeadingWhitespace
 from typing import Any
+
+from .EscapeLeadingWhitespace import EscapeLeadingWhitespace
+from .Literals import Language, LiteralFormat, LiteralValue
+from .Slice import Slice
 
 
 class SourceFile:

--- a/python/selfie-lib/selfie_lib/SourceFile.py
+++ b/python/selfie-lib/selfie_lib/SourceFile.py
@@ -1,4 +1,3 @@
-import re
 from .Slice import Slice
 from .Literals import Language, LiteralFormat, LiteralValue
 from .EscapeLeadingWhitespace import EscapeLeadingWhitespace

--- a/python/selfie-lib/selfie_lib/WithinTestGC.py
+++ b/python/selfie-lib/selfie_lib/WithinTestGC.py
@@ -1,5 +1,5 @@
-from typing import Iterable, Tuple, List
 from threading import Lock
+from typing import Iterable, List, Tuple
 
 from .ArrayMap import ArrayMap, ArraySet
 from .Snapshot import Snapshot

--- a/python/selfie-lib/selfie_lib/WithinTestGC.py
+++ b/python/selfie-lib/selfie_lib/WithinTestGC.py
@@ -1,4 +1,3 @@
-from re import S, T
 from typing import Iterable, Tuple, List
 from threading import Lock
 

--- a/python/selfie-lib/selfie_lib/WriteTracker.py
+++ b/python/selfie-lib/selfie_lib/WriteTracker.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from typing import List, Optional, Generic, TypeVar, Dict, cast
-from abc import ABC, abstractmethod
+from abc import ABC
 import inspect
 import threading
 import os

--- a/python/selfie-lib/selfie_lib/WriteTracker.py
+++ b/python/selfie-lib/selfie_lib/WriteTracker.py
@@ -1,16 +1,15 @@
-from pathlib import Path
-from typing import List, Optional, Generic, TypeVar, Dict, cast
-from abc import ABC
 import inspect
-import threading
 import os
+import threading
+from abc import ABC
 from functools import total_ordering
+from pathlib import Path
+from typing import Dict, Generic, List, Optional, TypeVar, cast
 
-from .SourceFile import SourceFile
-from .Literals import LiteralValue, LiteralTodoStub, TodoStub
-from .TypedPath import TypedPath
 from .FS import FS
-
+from .Literals import LiteralTodoStub, LiteralValue, TodoStub
+from .SourceFile import SourceFile
+from .TypedPath import TypedPath
 
 T = TypeVar("T")
 U = TypeVar("U")

--- a/python/selfie-lib/selfie_lib/__init__.py
+++ b/python/selfie-lib/selfie_lib/__init__.py
@@ -12,12 +12,12 @@ from .Slice import Slice as Slice
 from .Snapshot import Snapshot as Snapshot
 from .SnapshotFile import SnapshotFile as SnapshotFile
 from .SnapshotReader import SnapshotReader as SnapshotReader
-from .SnapshotSystem import _initSelfieSystem as _initSelfieSystem
-from .SnapshotSystem import _clearSelfieSystem as _clearSelfieSystem
-from .SnapshotSystem import _selfieSystem as _selfieSystem
 from .SnapshotSystem import DiskStorage as DiskStorage
 from .SnapshotSystem import Mode as Mode
 from .SnapshotSystem import SnapshotSystem as SnapshotSystem
+from .SnapshotSystem import _clearSelfieSystem as _clearSelfieSystem
+from .SnapshotSystem import _initSelfieSystem as _initSelfieSystem
+from .SnapshotSystem import _selfieSystem as _selfieSystem
 from .SnapshotValue import SnapshotValue as SnapshotValue
 from .SnapshotValueReader import SnapshotValueReader as SnapshotValueReader
 from .SourceFile import SourceFile as SourceFile
@@ -27,5 +27,5 @@ from .WriteTracker import CallLocation as CallLocation
 from .WriteTracker import CallStack as CallStack
 from .WriteTracker import DiskWriteTracker as DiskWriteTracker
 from .WriteTracker import InlineWriteTracker as InlineWriteTracker
-from .WriteTracker import recordCall as recordCall
 from .WriteTracker import SnapshotFileLayout as SnapshotFileLayout
+from .WriteTracker import recordCall as recordCall

--- a/python/selfie-lib/tests/ArrayMap_test.py
+++ b/python/selfie-lib/tests/ArrayMap_test.py
@@ -1,4 +1,5 @@
 import pytest
+
 from selfie_lib.ArrayMap import ArrayMap
 
 

--- a/python/selfie-lib/tests/LiteralInt_test.py
+++ b/python/selfie-lib/tests/LiteralInt_test.py
@@ -1,5 +1,5 @@
-from selfie_lib.Literals import LiteralInt, Language
 from selfie_lib.EscapeLeadingWhitespace import EscapeLeadingWhitespace
+from selfie_lib.Literals import Language, LiteralInt
 
 
 def _encode(value: int, expected: str):

--- a/python/selfie-lib/tests/LiteralString_test.py
+++ b/python/selfie-lib/tests/LiteralString_test.py
@@ -1,6 +1,7 @@
 import pytest
-from selfie_lib.Literals import LiteralString
+
 from selfie_lib.EscapeLeadingWhitespace import EscapeLeadingWhitespace
+from selfie_lib.Literals import LiteralString
 
 
 class TestLiteralString:

--- a/python/selfie-lib/tests/RecordCall_test.py
+++ b/python/selfie-lib/tests/RecordCall_test.py
@@ -29,7 +29,7 @@ def test_record_call_with_caller_file_only_false():
         len(call_stack.rest_of_stack) > 0
     ), "Expected the rest of stack to contain more than one CallLocation"
 
-    expected_call_location_str = "File: RecordCall_test.py, Line: 25"
+    expected_call_location_str = "File: RecordCall_test.py, Line: 26"
 
     if call_stack.location.file_name is not None:
         actual_file_name = os.path.basename(call_stack.location.file_name)

--- a/python/selfie-lib/tests/RecordCall_test.py
+++ b/python/selfie-lib/tests/RecordCall_test.py
@@ -1,6 +1,7 @@
-from unittest.mock import Mock
-from selfie_lib.WriteTracker import CallLocation, CallStack, recordCall
 import os
+from unittest.mock import Mock
+
+from selfie_lib.WriteTracker import CallLocation, CallStack, recordCall
 
 
 def test_call_location_ide_link():

--- a/python/selfie-lib/tests/SnapshotFile_test.py
+++ b/python/selfie-lib/tests/SnapshotFile_test.py
@@ -1,4 +1,4 @@
-from selfie_lib import SnapshotFile, SnapshotValueReader, Snapshot
+from selfie_lib import Snapshot, SnapshotFile, SnapshotValueReader
 
 
 def test_read_with_metadata():

--- a/python/selfie-lib/tests/SnapshotReader_test.py
+++ b/python/selfie-lib/tests/SnapshotReader_test.py
@@ -1,5 +1,6 @@
 from base64 import b64decode
-from selfie_lib import SnapshotValueReader, Snapshot, SnapshotReader
+
+from selfie_lib import Snapshot, SnapshotReader, SnapshotValueReader
 
 
 class TestSnapshotReader:

--- a/python/selfie-lib/tests/SnapshotValueReader_test.py
+++ b/python/selfie-lib/tests/SnapshotValueReader_test.py
@@ -1,5 +1,6 @@
 import pytest
-from selfie_lib import SnapshotValueReader, ParseException
+
+from selfie_lib import ParseException, SnapshotValueReader
 
 
 class TestSnapshotValueReader:

--- a/python/selfie-lib/tests/TypedPath_test.py
+++ b/python/selfie-lib/tests/TypedPath_test.py
@@ -1,4 +1,5 @@
 import pytest
+
 from selfie_lib.TypedPath import TypedPath
 
 


### PR DESCRIPTION
So it turns out that ruff keeps its formatter and linter totally separate. You can't call them together (???), they have their own commands.

- format (the only part we have been using
  - `ruff format --check` and `ruff format`
- lint (the thing that does import sorting and unused removal)
  - `ruff check` and `ruff --fix`

Go figure. Anyway, this messy PR fixes that and keeps it fixed with CI.