### PR TITLE
handle multiline java strings as comma-delimited single-line strings

### DIFF
--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -11,6 +11,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- For java versions which don't support multiline string literals, we now encode multiline strings like so:
+  - ```java
+    toBe("line1",
+         "line2",
+         "line3");
+    ```
+### Changed
+- Bump Kotlin to 2.0.0. ([#405](https://github.com/diffplug/selfie/pull/405))
 ### Fixed
 - Do not remove stale snapshot files when readonly is true. ([#367](https://github.com/diffplug/selfie/pull/367))
 

--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- For java versions which don't support multiline string literals, we now encode multiline strings like so:
+- For java versions which don't support multiline string literals, we now encode multiline strings like so: ([#406](https://github.com/diffplug/selfie/pull/406))
   - ```java
     toBe("line1",
          "line2",

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/SelfieImplementations.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/SelfieImplementations.kt
@@ -69,9 +69,8 @@ interface FluentFacet {
   fun facetBinary(facet: String): BinaryFacet
 }
 
-interface StringFacet : FluentFacet {
+expect interface StringFacet : FluentFacet {
   fun toBe(expected: String): String
-  fun toBe_TODO(unusedArg: Any?): String = toBe_TODO()
   fun toBe_TODO(): String
 }
 

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/Literals.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/Literals.kt
@@ -136,7 +136,7 @@ internal object LiteralString : LiteralFormat<String>() {
             // TODO: support triple-quoted strings in groovy
             // https://github.com/diffplug/selfie/issues/105
             Language.GROOVY,
-            Language.JAVA_PRE15 -> encodeSingleJava(value)
+            Language.JAVA_PRE15 -> encodeMultiAsSingleJava(value)
             Language.JAVA -> encodeMultiJava(value, encodingPolicy)
             Language.KOTLIN -> encodeMultiKotlin(value, encodingPolicy)
           }
@@ -200,6 +200,8 @@ internal object LiteralString : LiteralFormat<String>() {
     val toUnescape = if (removeDollars) inlineDollars(source) else source
     return unescapeJava(toUnescape)
   }
+  fun encodeMultiAsSingleJava(arg: String): String =
+      arg.lines().joinToString(",\n") { encodeSingleJava(it) }
   fun encodeMultiKotlin(arg: String, escapeLeadingWhitespace: EscapeLeadingWhitespace): String {
     val escapeDollars = arg.replace("$", KOTLIN_DOLLAR)
     val escapeTripleQuotes =

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/Literals.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/Literals.kt
@@ -145,7 +145,7 @@ internal object LiteralString : LiteralFormat<String>() {
           when (language) {
             Language.SCALA,
             Language.JAVA_PRE15,
-            Language.JAVA -> parseSingleJava(str)
+            Language.JAVA -> parseSingleJava(SourceFile.commaDelimitedParseCleanup(str))
             Language.GROOVY,
             Language.KOTLIN -> parseSingleJavaWithDollars(str)
           }

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SourceFile.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SourceFile.kt
@@ -168,6 +168,11 @@ class SourceFile(filename: String, content: String) {
         contentSlice.subSequence(dotFunctionCall, endParen + 1),
         fullArg)
   }
+
+  companion object {
+    internal inline fun commaDelimitedParseCleanup(str: String): String =
+        str.efficientReplace("\",\n\"", "\\n")
+  }
   private fun argSlice(
       argStartInitial: Int,
       dotFunOpenParen: String,

--- a/jvm/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/LiteralStringTest.kt
+++ b/jvm/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/LiteralStringTest.kt
@@ -101,7 +101,7 @@ class LiteralStringTest {
   }
 
   @Test
-  fun encodeMultiAsJava() {
+  fun encodeMultiAsSingleJava() {
     encodeMultiAsSingleJava(
         "1\n 2\n\t3",
         """

--- a/jvm/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/LiteralStringTest.kt
+++ b/jvm/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/LiteralStringTest.kt
@@ -99,4 +99,20 @@ class LiteralStringTest {
     val actual = LiteralString.parseSingleJavaWithDollars("\"${value}\"")
     actual shouldBe expected
   }
+
+  @Test
+  fun encodeMultiAsJava() {
+    encodeMultiAsSingleJava(
+        "1\n 2\n\t3",
+        """
+"1",
+" 2",
+"\t3"
+    """
+            .trimIndent())
+  }
+  private fun encodeMultiAsSingleJava(value: String, expected: String) {
+    val actual = LiteralString.encodeMultiAsSingleJava(value)
+    actual shouldBe expected.replace("'", "\"")
+  }
 }

--- a/jvm/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/SourceFileToBeTest.kt
+++ b/jvm/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/SourceFileToBeTest.kt
@@ -58,6 +58,11 @@ class SourceFileToBeTest {
   }
 
   @Test
+  fun multiLineStringAsSingle() {
+    javaTest(".toBe('1',\n' 2',\n'\\t3')", "'1\\n 2\\n\\t3'")
+  }
+
+  @Test
   fun errorUnclosed() {
     javaTestError(".toBe(", "Appears to be an unclosed function call `.toBe()` on line 1")
     javaTestError(".toBe(  \n ", "Appears to be an unclosed function call `.toBe()` on line 1")

--- a/jvm/selfie-lib/src/jsMain/kotlin/com/diffplug/selfie/SelfieImplementations.js.kt
+++ b/jvm/selfie-lib/src/jsMain/kotlin/com/diffplug/selfie/SelfieImplementations.js.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.selfie
+
+actual interface StringFacet : FluentFacet {
+  actual fun toBe(expected: String): String
+  actual fun toBe_TODO(): String
+  fun toBe_TODO(unusedArg: Any?): String = toBe_TODO()
+}

--- a/jvm/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/SelfieImplementations.jvm.kt
+++ b/jvm/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/SelfieImplementations.jvm.kt
@@ -19,4 +19,22 @@ actual interface StringFacet : FluentFacet {
   actual fun toBe(expected: String): String
   actual fun toBe_TODO(): String
   fun toBe_TODO(unusedArg: Any?): String = toBe_TODO()
+
+  // the methods below are aliases for multiline strings for JAVA_PRE15
+  fun toBe_TODO(
+      expected: String,
+      expectedLine2: String,
+      vararg expectedOtherLines: String
+  ): String = toBe_TODO()
+  fun toBe(expected: String, expectedLine2: String, vararg expectedOtherLines: String): String {
+    val buffer = StringBuilder()
+    buffer.append(expected)
+    buffer.append("\n")
+    buffer.append(expectedLine2)
+    for (line in expectedOtherLines) {
+      buffer.append("\n")
+      buffer.append(line)
+    }
+    return buffer.toString()
+  }
 }

--- a/jvm/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/SelfieImplementations.jvm.kt
+++ b/jvm/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/SelfieImplementations.jvm.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.selfie
+
+actual interface StringFacet : FluentFacet {
+  actual fun toBe(expected: String): String
+  actual fun toBe_TODO(): String
+  fun toBe_TODO(unusedArg: Any?): String = toBe_TODO()
+}

--- a/jvm/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/SelfieImplementations.jvm.kt
+++ b/jvm/selfie-lib/src/jvmMain/kotlin/com/diffplug/selfie/SelfieImplementations.jvm.kt
@@ -16,16 +16,23 @@
 package com.diffplug.selfie
 
 actual interface StringFacet : FluentFacet {
+  /** Expects this string to be equal to the expected string. */
   actual fun toBe(expected: String): String
+
+  /** Marks that the expected value should be written when the test executes. */
   actual fun toBe_TODO(): String
+
+  /** Alias for [toBe_TODO], the argument is ignored. */
   fun toBe_TODO(unusedArg: Any?): String = toBe_TODO()
 
-  // the methods below are aliases for multiline strings for JAVA_PRE15
+  /** Alias for [toBe_TODO], the arguments are ignored. */
   fun toBe_TODO(
       expected: String,
       expectedLine2: String,
       vararg expectedOtherLines: String
   ): String = toBe_TODO()
+
+  /** Expects this string to be equal to the value of all its arguments concatenated by newlines. */
   fun toBe(expected: String, expectedLine2: String, vararg expectedOtherLines: String): String {
     val buffer = StringBuilder()
     buffer.append(expected)


### PR DESCRIPTION
For java versions which don't support multiline literals, we now do assertions on multiline strings like this:

```java
toBe("line1",
     "line2",
     "line3");
```