### PR TITLE
Added `Selfie.expectSelfie` for easy "multi-asserts"

### DIFF
--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -11,7 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
+- Added `Selfie.expectSelfies(Iterable<T> items, Function<T, String> toString)` for doing easy "multi-asserts". ([#415](https://github.com/diffplug/selfie/pull/415))
 - For java versions which don't support multiline string literals, we now encode multiline strings like so: ([#406](https://github.com/diffplug/selfie/pull/406))
   - ```java
     toBe("line1",

--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -11,9 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
-- Added `Selfie.expectSelfies(Iterable<T> items, Function<T, String> toString)` for doing easy "multi-asserts". ([#415](https://github.com/diffplug/selfie/pull/415))
+- Added `Selfie.expectSelfies(Iterable<T> items, Function<T, String> toString)` for doing easy "multi-asserts". ([#416](https://github.com/diffplug/selfie/pull/416))
 - For java versions which don't support multiline string literals, we now encode multiline strings like so: ([#406](https://github.com/diffplug/selfie/pull/406))
   - ```java
     toBe("line1",

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Selfie.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Selfie.kt
@@ -64,6 +64,12 @@ object Selfie {
   @JvmStatic fun expectSelfie(actual: Boolean) = BooleanSelfie(actual)
 
   @JvmStatic
+  fun <T> expectSelfies(items: Iterable<T>, toString: (T) -> String): StringSelfie {
+    val snapshots = items.joinToString("\n", transform = toString)
+    return expectSelfie(snapshots)
+  }
+
+  @JvmStatic
   fun cacheSelfie(toCache: Cacheable<String>) = cacheSelfie(Roundtrip.identity(), toCache)
 
   @JvmStatic


### PR DESCRIPTION
Users could easily make this on their own, but I've been using it so often it's probably worth upstreaming into the "factory settings".