### PR TITLE
Fix default arguments for `cacheSelfie`.

### DIFF
--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `cacheSelfie` was missing `@JvmOverloads` on the methods with default arguments. ([#425](https://github.com/diffplug/selfie/pull/425))
 
 ## [2.2.1] - 2024-06-05
 ### Fixed

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/CacheSelfie.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/CacheSelfie.kt
@@ -20,15 +20,19 @@ import com.diffplug.selfie.guts.LiteralString
 import com.diffplug.selfie.guts.LiteralValue
 import com.diffplug.selfie.guts.TodoStub
 import com.diffplug.selfie.guts.recordCall
+import kotlin.jvm.JvmOverloads
 
 class CacheSelfie<T>(
     private val disk: DiskStorage,
     private val roundtrip: Roundtrip<T, String>,
     private val generator: Cacheable<T>
 ) {
+  @JvmOverloads
   fun toMatchDisk(sub: String = ""): T {
     return toMatchDiskImpl(sub, false)
   }
+
+  @JvmOverloads
   fun toMatchDisk_TODO(sub: String = ""): T {
     return toMatchDiskImpl(sub, true)
   }
@@ -57,6 +61,8 @@ class CacheSelfie<T>(
       }
     }
   }
+
+  @JvmOverloads
   fun toBe_TODO(unusedArg: Any? = null): T {
     return toBeImpl(null)
   }


### PR DESCRIPTION
`cacheSelfie` was missing `@JvmOverloads` on the methods with default arguments.