### PR TITLE
`DiskSelfie` now makes the `Snapshot actual` value public

### DIFF
--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `DiskSelfie` now makes the `Snapshot actual` value public, so that other testing infrastructure can read from snapshotted values.
 ### Fixed
 - `cacheSelfie` was missing `@JvmOverloads` on the methods with default arguments. ([#425](https://github.com/diffplug/selfie/pull/425))
 

--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- `DiskSelfie` now makes the `Snapshot actual` value public, so that other testing infrastructure can read from snapshotted values.
+- `DiskSelfie` now makes the `Snapshot actual` value public, so that other testing infrastructure can read from snapshotted values. ([#467](https://github.com/diffplug/selfie/pull/467))
 ### Fixed
 - `cacheSelfie` was missing `@JvmOverloads` on the methods with default arguments. ([#425](https://github.com/diffplug/selfie/pull/425))
 

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/SelfieImplementations.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/SelfieImplementations.kt
@@ -30,8 +30,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.jvm.JvmOverloads
 
 /** A selfie which can be stored into a selfie-managed file. */
-open class DiskSelfie
-internal constructor(val actual: Snapshot, protected val disk: DiskStorage) :
+open class DiskSelfie internal constructor(val actual: Snapshot, protected val disk: DiskStorage) :
     FluentFacet {
   @JvmOverloads
   open fun toMatchDisk(sub: String = ""): DiskSelfie {

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/SelfieImplementations.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/SelfieImplementations.kt
@@ -31,7 +31,7 @@ import kotlin.jvm.JvmOverloads
 
 /** A selfie which can be stored into a selfie-managed file. */
 open class DiskSelfie
-internal constructor(protected val actual: Snapshot, protected val disk: DiskStorage) :
+internal constructor(val actual: Snapshot, protected val disk: DiskStorage) :
     FluentFacet {
   @JvmOverloads
   open fun toMatchDisk(sub: String = ""): DiskSelfie {


### PR DESCRIPTION
so that other testing infrastructure can read from snapshotted values.