### PR TITLE
Better error messages

### DIFF
--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -1,5 +1,4 @@
 # Changelog
-
 Changelog for the selfie JVM libraries.
 
 - [`com.diffplug.selfie:selfie-lib:VERSION`](https://central.sonatype.com/artifact/com.diffplug.selfie/selfie-lib)
@@ -8,13 +7,11 @@ Changelog for the selfie JVM libraries.
   - works with Kotest JVM
 - [`com.diffplug.selfie:selfie-runner-kotest:VERSION`](https://central.sonatype.com/artifact/com.diffplug.selfie/selfie-runner-kotest)
   - written in Kotlin Multiplatform
-    The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-    and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
-
 - Snapshot mismatch error messages now show a diff of the first mismatched line. ([#477](https://github.com/diffplug/selfie/pull/477))
   - before
     ```
@@ -32,31 +29,21 @@ Changelog for the selfie JVM libraries.
     ```
 
 ## [2.3.0] - 2024-07-11
-
 ### Added
-
 - `DiskSelfie` now makes the `Snapshot actual` value public, so that other testing infrastructure can read from snapshotted values. ([#467](https://github.com/diffplug/selfie/pull/467))
-
 ### Fixed
-
 - `cacheSelfie` was missing `@JvmOverloads` on the methods with default arguments. ([#425](https://github.com/diffplug/selfie/pull/425))
 
 ## [2.2.1] - 2024-06-05
-
 ### Fixed
-
 - Added `Selfie.expectSelfies(Iterable<T> items, Function<T, String> toString)` for doing easy "multi-asserts" in `suspend fun` also. ([#421](https://github.com/diffplug/selfie/pull/421))
 
 ## [2.2.0] - 2024-06-04
-
 ### Added
-
 - `SelfieSettingsAPI` now has a field `javaDontUseTripleQuoteLiterals` which ensures that multiline strings are always encoded as `"` strings. ([#417](https://github.com/diffplug/selfie/pull/417))
 
 ## [2.1.0] - 2024-06-03
-
 ### Added
-
 - Added `Selfie.expectSelfies(Iterable<T> items, Function<T, String> toString)` for doing easy "multi-asserts". ([#416](https://github.com/diffplug/selfie/pull/416))
 - For java versions which don't support multiline string literals, we now encode multiline strings like so: ([#406](https://github.com/diffplug/selfie/pull/406))
   - ```java
@@ -64,146 +51,102 @@ Changelog for the selfie JVM libraries.
          "line2",
          "line3");
     ```
-
 ### Changed
-
 - Bump Kotlin to 2.0.0. ([#405](https://github.com/diffplug/selfie/pull/405))
-
 ### Fixed
-
 - Do not remove stale snapshot files when readonly is true. ([#367](https://github.com/diffplug/selfie/pull/367))
 - Provide more debugging info when a snapshot gets set multiple times. (helps with [#370](https://github.com/diffplug/selfie/issues/370))
 
 ## [2.0.2] - 2024-03-20
-
 ### Fixed
-
 - `toBeFile` now checks for duplicate writes and throws a more helpful error message if the file doesn't exist. ([#277](https://github.com/diffplug/selfie/pull/277))
 
 ## [2.0.1] - 2024-02-24
-
 ### Fixed
-
 - The `coroutines` methods used to eagerly throw an exception if they were ever called from anywhere besides a Kotest method. Now they wait until `toMatchDisk()` is called, because they can work just fine anywhere if you use `toBe`. ([#247](https://github.com/diffplug/selfie/pull/247))
 
 ## [2.0.0] - 2024-02-21
-
 ### Added
-
 - **Memoization** ([#219](https://github.com/diffplug/selfie/pull/219) implements [#215](https://github.com/diffplug/selfie/issues/215))
-  - like `expectSelfie`, all are available as `Selfie.cacheSelfie` or as `suspend fun` in `com.diffplug.selfie.coroutines`.
-
+  - like `expectSelfie`, all are available as `Selfie.cacheSelfie` or as `suspend fun` in `com.diffplug.selfie.coroutines`. 
 ```kotlin
 val cachedResult: ByteArray = Selfie.cacheSelfieBinary { dalleJpeg() }.toBeFile("example.jpg")
 val cachedResult: String    = Selfie.cacheSelfie { someString() }.toBe("what it was earlier")
 val cachedResult: T         = Selfie.cacheSelfieJson { anyKotlinxSerializable() }.toBe("""{"key": "value"}""")
 val cachedResult: T         = Selfie.cacheSelfieBinarySerializable { anyJavaIoSerializable() }.toMatchDisk()
 ```
-
 - `toBeBase64` and `toBeFile` for true binary comparison of binary snapshots and facets. ([#224](https://github.com/diffplug/selfie/pull/224))
 - spaces in multiline string literals aren't always escaped. ([#220](https://github.com/diffplug/selfie/issues/220))
   - if the leading spaces in the string literal match the file's existing indentation
-
 ### Changed
-
 - **BREAKING** reordered a class hierarchy for better binary support. ([#221](https://github.com/diffplug/selfie/issues/221))
   - most users won't need to make any changes at all
   - only exception is that `expectSelfie(byte[]).toBe` is now a compile error, must do `toBeBase64`
 
 ## [1.2.0] - 2024-02-12
-
 ### Added
-
 - **Kotest support**.
   - Add `SelfieExtension` to your `AbstractProjectConfig`.
   - Instead of calling `Selfie.expectSelfie`, call `com.diffplug.selfie.coroutines.expectSelfie`.
   - `selfie-runner-junit5` supports snapshots in regular JUnit tests and Kotest tests in the same project.
   - `selfie-runner-kotest` is a new selfie implemented in Kotlin Multiplatform, but doesn't support snapshots within regular JUnit tests.
   - Full docs at https://selfie.dev/jvm/kotest.
-
 ### Fixed
-
 - Swap thread-local cache for thread-ignorant LRU to improve performance when used with coroutines. ([#191](https://github.com/diffplug/selfie/pull/191))
-
 ### Changes
-
 - (no user-facing changes) replaced terrible platform-specific `Path` with `TypedPath`. ([#184](https://github.com/diffplug/selfie/pull/184))
 - (no user-facing changes) replaced `SnapshotStorage` with `SnapshotSystem` + `DiskStorage`. ([#198](https://github.com/diffplug/selfie/pull/198))
 - (no user-facing changes) replaced most `synchronized` with CAS. ([#199](https://github.com/diffplug/selfie/pull/199))
 
 ## [1.1.2] - 2024-01-30
-
 ### Fixed
-
 - `@ParameterizedTest` no longer has. ([#140](https://github.com/diffplug/selfie/issues/140))
 - If a test class contained package-private methods and a single test method was run without the others, selfie would erroneously garbage collect disk snapshots for the other methods, now fixed. ([#175](https://github.com/diffplug/selfie/pull/175) fixes [#174](https://github.com/diffplug/selfie/issues/174))
 
 ## [1.1.1] - 2024-01-25
-
 ### Fixed
-
 - Selfie was erroneously garbage collecting snapshots when a test class contained no `@Test public` methods. ([#124](https://github.com/diffplug/selfie/pull/124) fixes [#123](https://github.com/diffplug/selfie/issues/123))
 
 ## [1.1.0] - 2024-01-21
-
 ### Added
-
 - Support for `@ParameterizedTest`. ([#118](https://github.com/diffplug/selfie/pull/118))
 - `ArraySet<K>` has been added to the standard library alongside `ArrayMap<K, V>`. ([#119](https://github.com/diffplug/selfie/pull/119))
   - These have the strange property that if the key is `String`, then `/` characters are sorted to be the lowest possible character.
-
 ### Fixed
-
 - We already [smuggle errors from initialization](https://github.com/diffplug/selfie/pull/94) to help debug them, and now we also smuggle errors that happen during test execution. ([#117](https://github.com/diffplug/selfie/pull/117))
 - Fix a garbage collection bug which occurred when a test method's name was a prefix of another test method's name. ([#119](https://github.com/diffplug/selfie/pull/119))
 
 ## [1.0.1] - 2024-01-19
-
 ### Fixed
-
 - Fix `CompoundLens` for Java users.
 
 ## [1.0.0] - 2024-01-18
-
 ### Added
-
 - Full support for binary snapshots. ([#108](https://github.com/diffplug/selfie/pull/108))
-
 ### Fixed
-
 - Groovy multiline string values just go into `"` strings instead of `"""` until we have a chance to implement them properly. ([#107](https://github.com/diffplug/selfie/pull/107))
 
 ## [0.3.0] - 2024-01-17
-
 ### Added
-
 - `toBe("mismatched")` now gets rewritten in write mode
 - fully implemented the new control scheme ([#74](https://github.com/diffplug/selfie/issues/74))
 - integers get `_` separators for thousands, millions, etc
-
 ### Known broken
-
 - Groovy multiline strings
 - Binary
 
 ## [0.2.0] - 2023-12-27
-
 ### Added
-
 - `DiskSelfie.toMatchDisk` now returns `DiskSelfie` so that we can fluently chain inline assertions on facets.
 
 ## [0.1.3] - 2023-12-26
-
-- Publish `selfie-lib-jvm` _and_ `selfie-lib` to Maven Central.
+- Publish `selfie-lib-jvm` *and* `selfie-lib` to Maven Central.
 
 ## [0.1.2] - 2023-12-26
-
 - Publish `selfie-lib-jvm` instead of just `selfie-lib` to Maven Central.
 
 ## [0.1.1] - 2023-12-24
-
 - Initial release, take 2.
 
 ## [0.1.0] - 2023-12-24
-
 - Initial release.

--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 Changelog for the selfie JVM libraries.
 
 - [`com.diffplug.selfie:selfie-lib:VERSION`](https://central.sonatype.com/artifact/com.diffplug.selfie/selfie-lib)
@@ -7,27 +8,55 @@ Changelog for the selfie JVM libraries.
   - works with Kotest JVM
 - [`com.diffplug.selfie:selfie-runner-kotest:VERSION`](https://central.sonatype.com/artifact/com.diffplug.selfie/selfie-runner-kotest)
   - written in Kotlin Multiplatform
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+    The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+    and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [2.3.0] - 2024-07-11
 ### Added
+
+- Snapshot mismatch error messages now show a diff of the first mismatched line. ([#477](https://github.com/diffplug/selfie/pull/477))
+  - before
+    ```
+    Snapshot mismatch
+    - update this snapshot by adding `_TODO` to the function name
+    - update all snapshots in this file by adding `//selfieonce` or `//SELFIEWRITE`
+    ```
+  - after
+    ```
+    Snapshot mismatch at L7:C9
+    -Testing 123
+    +Testing ABC
+    ‣ update this snapshot by adding `_TODO` to the function name
+    ‣ update all snapshots in this file by adding `//selfieonce` or `//SELFIEWRITE`
+    ```
+
+## [2.3.0] - 2024-07-11
+
+### Added
+
 - `DiskSelfie` now makes the `Snapshot actual` value public, so that other testing infrastructure can read from snapshotted values. ([#467](https://github.com/diffplug/selfie/pull/467))
+
 ### Fixed
+
 - `cacheSelfie` was missing `@JvmOverloads` on the methods with default arguments. ([#425](https://github.com/diffplug/selfie/pull/425))
 
 ## [2.2.1] - 2024-06-05
+
 ### Fixed
+
 - Added `Selfie.expectSelfies(Iterable<T> items, Function<T, String> toString)` for doing easy "multi-asserts" in `suspend fun` also. ([#421](https://github.com/diffplug/selfie/pull/421))
 
 ## [2.2.0] - 2024-06-04
+
 ### Added
+
 - `SelfieSettingsAPI` now has a field `javaDontUseTripleQuoteLiterals` which ensures that multiline strings are always encoded as `"` strings. ([#417](https://github.com/diffplug/selfie/pull/417))
 
 ## [2.1.0] - 2024-06-03
+
 ### Added
+
 - Added `Selfie.expectSelfies(Iterable<T> items, Function<T, String> toString)` for doing easy "multi-asserts". ([#416](https://github.com/diffplug/selfie/pull/416))
 - For java versions which don't support multiline string literals, we now encode multiline strings like so: ([#406](https://github.com/diffplug/selfie/pull/406))
   - ```java
@@ -35,102 +64,146 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
          "line2",
          "line3");
     ```
+
 ### Changed
+
 - Bump Kotlin to 2.0.0. ([#405](https://github.com/diffplug/selfie/pull/405))
+
 ### Fixed
+
 - Do not remove stale snapshot files when readonly is true. ([#367](https://github.com/diffplug/selfie/pull/367))
 - Provide more debugging info when a snapshot gets set multiple times. (helps with [#370](https://github.com/diffplug/selfie/issues/370))
 
 ## [2.0.2] - 2024-03-20
+
 ### Fixed
+
 - `toBeFile` now checks for duplicate writes and throws a more helpful error message if the file doesn't exist. ([#277](https://github.com/diffplug/selfie/pull/277))
 
 ## [2.0.1] - 2024-02-24
+
 ### Fixed
+
 - The `coroutines` methods used to eagerly throw an exception if they were ever called from anywhere besides a Kotest method. Now they wait until `toMatchDisk()` is called, because they can work just fine anywhere if you use `toBe`. ([#247](https://github.com/diffplug/selfie/pull/247))
 
 ## [2.0.0] - 2024-02-21
+
 ### Added
+
 - **Memoization** ([#219](https://github.com/diffplug/selfie/pull/219) implements [#215](https://github.com/diffplug/selfie/issues/215))
-  - like `expectSelfie`, all are available as `Selfie.cacheSelfie` or as `suspend fun` in `com.diffplug.selfie.coroutines`. 
+  - like `expectSelfie`, all are available as `Selfie.cacheSelfie` or as `suspend fun` in `com.diffplug.selfie.coroutines`.
+
 ```kotlin
 val cachedResult: ByteArray = Selfie.cacheSelfieBinary { dalleJpeg() }.toBeFile("example.jpg")
 val cachedResult: String    = Selfie.cacheSelfie { someString() }.toBe("what it was earlier")
 val cachedResult: T         = Selfie.cacheSelfieJson { anyKotlinxSerializable() }.toBe("""{"key": "value"}""")
 val cachedResult: T         = Selfie.cacheSelfieBinarySerializable { anyJavaIoSerializable() }.toMatchDisk()
 ```
+
 - `toBeBase64` and `toBeFile` for true binary comparison of binary snapshots and facets. ([#224](https://github.com/diffplug/selfie/pull/224))
 - spaces in multiline string literals aren't always escaped. ([#220](https://github.com/diffplug/selfie/issues/220))
   - if the leading spaces in the string literal match the file's existing indentation
+
 ### Changed
+
 - **BREAKING** reordered a class hierarchy for better binary support. ([#221](https://github.com/diffplug/selfie/issues/221))
   - most users won't need to make any changes at all
   - only exception is that `expectSelfie(byte[]).toBe` is now a compile error, must do `toBeBase64`
 
 ## [1.2.0] - 2024-02-12
+
 ### Added
+
 - **Kotest support**.
   - Add `SelfieExtension` to your `AbstractProjectConfig`.
   - Instead of calling `Selfie.expectSelfie`, call `com.diffplug.selfie.coroutines.expectSelfie`.
   - `selfie-runner-junit5` supports snapshots in regular JUnit tests and Kotest tests in the same project.
   - `selfie-runner-kotest` is a new selfie implemented in Kotlin Multiplatform, but doesn't support snapshots within regular JUnit tests.
   - Full docs at https://selfie.dev/jvm/kotest.
+
 ### Fixed
+
 - Swap thread-local cache for thread-ignorant LRU to improve performance when used with coroutines. ([#191](https://github.com/diffplug/selfie/pull/191))
+
 ### Changes
+
 - (no user-facing changes) replaced terrible platform-specific `Path` with `TypedPath`. ([#184](https://github.com/diffplug/selfie/pull/184))
 - (no user-facing changes) replaced `SnapshotStorage` with `SnapshotSystem` + `DiskStorage`. ([#198](https://github.com/diffplug/selfie/pull/198))
 - (no user-facing changes) replaced most `synchronized` with CAS. ([#199](https://github.com/diffplug/selfie/pull/199))
 
 ## [1.1.2] - 2024-01-30
+
 ### Fixed
+
 - `@ParameterizedTest` no longer has. ([#140](https://github.com/diffplug/selfie/issues/140))
 - If a test class contained package-private methods and a single test method was run without the others, selfie would erroneously garbage collect disk snapshots for the other methods, now fixed. ([#175](https://github.com/diffplug/selfie/pull/175) fixes [#174](https://github.com/diffplug/selfie/issues/174))
 
 ## [1.1.1] - 2024-01-25
+
 ### Fixed
+
 - Selfie was erroneously garbage collecting snapshots when a test class contained no `@Test public` methods. ([#124](https://github.com/diffplug/selfie/pull/124) fixes [#123](https://github.com/diffplug/selfie/issues/123))
 
 ## [1.1.0] - 2024-01-21
+
 ### Added
+
 - Support for `@ParameterizedTest`. ([#118](https://github.com/diffplug/selfie/pull/118))
 - `ArraySet<K>` has been added to the standard library alongside `ArrayMap<K, V>`. ([#119](https://github.com/diffplug/selfie/pull/119))
   - These have the strange property that if the key is `String`, then `/` characters are sorted to be the lowest possible character.
+
 ### Fixed
+
 - We already [smuggle errors from initialization](https://github.com/diffplug/selfie/pull/94) to help debug them, and now we also smuggle errors that happen during test execution. ([#117](https://github.com/diffplug/selfie/pull/117))
 - Fix a garbage collection bug which occurred when a test method's name was a prefix of another test method's name. ([#119](https://github.com/diffplug/selfie/pull/119))
 
 ## [1.0.1] - 2024-01-19
+
 ### Fixed
+
 - Fix `CompoundLens` for Java users.
 
 ## [1.0.0] - 2024-01-18
+
 ### Added
+
 - Full support for binary snapshots. ([#108](https://github.com/diffplug/selfie/pull/108))
+
 ### Fixed
+
 - Groovy multiline string values just go into `"` strings instead of `"""` until we have a chance to implement them properly. ([#107](https://github.com/diffplug/selfie/pull/107))
 
 ## [0.3.0] - 2024-01-17
+
 ### Added
+
 - `toBe("mismatched")` now gets rewritten in write mode
 - fully implemented the new control scheme ([#74](https://github.com/diffplug/selfie/issues/74))
 - integers get `_` separators for thousands, millions, etc
+
 ### Known broken
+
 - Groovy multiline strings
 - Binary
 
 ## [0.2.0] - 2023-12-27
+
 ### Added
+
 - `DiskSelfie.toMatchDisk` now returns `DiskSelfie` so that we can fluently chain inline assertions on facets.
 
 ## [0.1.3] - 2023-12-26
-- Publish `selfie-lib-jvm` *and* `selfie-lib` to Maven Central.
+
+- Publish `selfie-lib-jvm` _and_ `selfie-lib` to Maven Central.
 
 ## [0.1.2] - 2023-12-26
+
 - Publish `selfie-lib-jvm` instead of just `selfie-lib` to Maven Central.
 
 ## [0.1.1] - 2023-12-24
+
 - Initial release, take 2.
 
 ## [0.1.0] - 2023-12-24
+
 - Initial release.

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Mode.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Mode.kt
@@ -62,9 +62,9 @@ enum class Mode {
   private fun msg(headline: String) =
       when (this) {
         interactive ->
-            "$headline\n" + (if (headline.any { it == '\n' }) "────────────────────\n" else "") +
-                "- update this snapshot by adding `_TODO` to the function name\n" +
-                "- update all snapshots in this file by adding `//selfieonce` or `//SELFIEWRITE`"
+            "$headline\n" +
+                "‣ update this snapshot by adding `_TODO` to the function name\n" +
+                "‣ update all snapshots in this file by adding `//selfieonce` or `//SELFIEWRITE`"
         readonly -> headline
         overwrite -> "$headline\n(didn't expect this to ever happen in overwrite mode)"
       }

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Mode.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/Mode.kt
@@ -42,7 +42,9 @@ enum class Mode {
   internal fun msgSnapshotNotFound() = msg("Snapshot not found")
   internal fun msgSnapshotNotFoundNoSuchFile(file: TypedPath) =
       msg("Snapshot not found: no such file $file")
-  internal fun msgSnapshotMismatch() = msg("Snapshot mismatch")
+  internal fun msgSnapshotMismatch(expected: String, actual: String) = msg("Snapshot mismatch")
+  internal fun msgSnapshotMismatchBinary(expected: ByteArray, actual: ByteArray) =
+      msg("Snapshot mismatch")
   private fun msg(headline: String) =
       when (this) {
         interactive ->

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/SelfieImplementations.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/SelfieImplementations.kt
@@ -146,7 +146,9 @@ class BinarySelfie(actual: Snapshot, disk: DiskStorage, private val onlyFacet: S
           return actualBytes
         } else {
           throw Selfie.system.fs.assertFailed(
-              Selfie.system.mode.msgSnapshotMismatch(), expected, actualBytes)
+              Selfie.system.mode.msgSnapshotMismatchBinary(expected, actualBytes),
+              expected,
+              actualBytes)
         }
       }
     }
@@ -241,7 +243,9 @@ private fun <T : Any> toBeDidntMatch(expected: T?, actual: T, format: LiteralFor
       throw Selfie.system.fs.assertFailed("Can't call `toBe_TODO` in ${Mode.readonly} mode!")
     } else {
       throw Selfie.system.fs.assertFailed(
-          Selfie.system.mode.msgSnapshotMismatch(), expected, actual)
+          Selfie.system.mode.msgSnapshotMismatch(expected.toString(), actual.toString()),
+          expected,
+          actual)
     }
   }
 }
@@ -263,10 +267,12 @@ private fun assertEqual(expected: Snapshot?, actual: Snapshot, storage: Snapshot
               .filter { expected.subjectOrFacetMaybe(it) != actual.subjectOrFacetMaybe(it) }
               .toList()
               .sorted()
+      val expectedFacets = serializeOnlyFacets(expected, mismatchedKeys)
+      val actualFacets = serializeOnlyFacets(actual, mismatchedKeys)
       throw storage.fs.assertFailed(
-          storage.mode.msgSnapshotMismatch(),
-          serializeOnlyFacets(expected, mismatchedKeys),
-          serializeOnlyFacets(actual, mismatchedKeys))
+          storage.mode.msgSnapshotMismatch(expectedFacets, actualFacets),
+          expectedFacets,
+          actualFacets)
     }
   }
 }

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotNotEqualErrorMsg.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotNotEqualErrorMsg.kt
@@ -48,23 +48,12 @@ object SnapshotNotEqualErrorMsg {
 
     if (endOfLineActual == endOfLineExpected) {
       // it ended at a line break
-      if (actual.length > expected.length) {
-        val line =
-            actual.let { str ->
-              val endIdx =
-                  str.indexOf('\n', endOfLineActual + 1).let { if (it == -1) str.length else it }
-              str.substring(endOfLineActual + 1, endIdx)
-            }
-        return "Snapshot mismatch at L${lineNumber+1}:C1 - line(s) added\n+$line"
-      } else {
-        val line =
-            expected.let { str ->
-              val endIdx =
-                  str.indexOf('\n', endOfLineActual + 1).let { if (it == -1) str.length else it }
-              str.substring(endOfLineActual + 1, endIdx)
-            }
-        return "Snapshot mismatch at L${lineNumber+1}:C1 - line(s) removed\n-$line"
-      }
+      val longer = if (actual.length > expected.length) actual else expected
+      val added = if (actual.length > expected.length) "+" else "-"
+      val endIdx =
+          longer.indexOf('\n', endOfLineActual + 1).let { if (it == -1) longer.length else it }
+      val line = longer.substring(endOfLineActual + 1, endIdx)
+      return "Snapshot mismatch at L${lineNumber+1}:C1 - line(s) ${if (added == "+") "added" else "removed"}\n${added}$line"
     } else {
       val expectedLine = expected.substring(index - columnNumber + 1, endOfLineExpected)
       val actualLine = actual.substring(index - columnNumber + 1, endOfLineActual)

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotNotEqualErrorMsg.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/guts/SnapshotNotEqualErrorMsg.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.selfie.guts
+
+object SnapshotNotEqualErrorMsg {
+  const val REASONABLE_LINE_LENGTH = 120
+  fun forUnequalStrings(expected: String, actual: String): String {
+    var lineNumber = 1
+    var columnNumber = 1
+    var index = 0
+
+    while (index < expected.length && index < actual.length) {
+      val expectedChar = expected[index]
+      val actualChar = actual[index]
+      if (expectedChar != actualChar) {
+        val endOfLineExpected =
+            expected.indexOf('\n', index).let { if (it == -1) expected.length else it }
+        val endOfLineActual =
+            actual.indexOf('\n', index).let { if (it == -1) actual.length else it }
+        val expectedLine = expected.substring(index - columnNumber + 1, endOfLineExpected)
+        val actualLine = actual.substring(index - columnNumber + 1, endOfLineActual)
+        return "Snapshot mismatch at L$lineNumber:C$columnNumber\n-$expectedLine\n+$actualLine"
+      }
+      if (expectedChar == '\n') {
+        lineNumber++
+        columnNumber = 1
+      } else {
+        columnNumber++
+      }
+      index++
+    }
+    if (expected.length != actual.length) {
+      //            val diffString = if (expected.length < actual.length) "Actual is longer" else
+      // "Expected is longer"
+      return "Snapshot mismatch at L$lineNumber:C$columnNumber"
+    }
+    throw IllegalArgumentException("The strings were supposed to be unequal")
+  }
+}

--- a/jvm/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/SnapshotNotEqualErrorMsgTest.kt
+++ b/jvm/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/SnapshotNotEqualErrorMsgTest.kt
@@ -44,4 +44,54 @@ class SnapshotNotEqualErrorMsgTest {
 -123 Testing
 +ABC Testing"""
   }
+
+  @Test
+  fun extraLine1() {
+    SnapshotNotEqualErrorMsg.forUnequalStrings("123", "123ABC") shouldBe
+        """Snapshot mismatch at L1:C4
+-123
++123ABC"""
+    SnapshotNotEqualErrorMsg.forUnequalStrings("123ABC", "123") shouldBe
+        """Snapshot mismatch at L1:C4
+-123ABC
++123"""
+  }
+
+  @Test
+  fun extraLine2() {
+    SnapshotNotEqualErrorMsg.forUnequalStrings("line\n123", "line\n123ABC") shouldBe
+        """Snapshot mismatch at L2:C4
+-123
++123ABC"""
+    SnapshotNotEqualErrorMsg.forUnequalStrings("line\n123ABC", "line\n123") shouldBe
+        """Snapshot mismatch at L2:C4
+-123ABC
++123"""
+  }
+
+  @Test
+  fun extraLine() {
+    SnapshotNotEqualErrorMsg.forUnequalStrings("line", "line\nnext") shouldBe
+        """Snapshot mismatch at L2:C1 - line(s) added
++next"""
+    SnapshotNotEqualErrorMsg.forUnequalStrings("line\nnext", "line") shouldBe
+        """Snapshot mismatch at L2:C1 - line(s) removed
+-next"""
+  }
+
+  @Test
+  fun extraNewline() {
+    SnapshotNotEqualErrorMsg.forUnequalStrings("line", "line\n") shouldBe
+        """Snapshot mismatch at L2:C1 - line(s) added
++"""
+    SnapshotNotEqualErrorMsg.forUnequalStrings("line\n", "line") shouldBe
+        """Snapshot mismatch at L2:C1 - line(s) removed
+-"""
+    SnapshotNotEqualErrorMsg.forUnequalStrings("", "\n") shouldBe
+        """Snapshot mismatch at L2:C1 - line(s) added
++"""
+    SnapshotNotEqualErrorMsg.forUnequalStrings("\n", "") shouldBe
+        """Snapshot mismatch at L2:C1 - line(s) removed
+-"""
+  }
 }

--- a/jvm/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/SnapshotNotEqualErrorMsgTest.kt
+++ b/jvm/selfie-lib/src/commonTest/kotlin/com/diffplug/selfie/guts/SnapshotNotEqualErrorMsgTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.selfie.guts
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class SnapshotNotEqualErrorMsgTest {
+  @Test
+  fun errorLine1() {
+    SnapshotNotEqualErrorMsg.forUnequalStrings("Testing 123", "Testing ABC") shouldBe
+        """Snapshot mismatch at L1:C9
+-Testing 123
++Testing ABC"""
+
+    SnapshotNotEqualErrorMsg.forUnequalStrings("123 Testing", "ABC Testing") shouldBe
+        """Snapshot mismatch at L1:C1
+-123 Testing
++ABC Testing"""
+  }
+
+  @Test
+  fun errorLine2() {
+    SnapshotNotEqualErrorMsg.forUnequalStrings("Line\nTesting 123", "Line\nTesting ABC") shouldBe
+        """Snapshot mismatch at L2:C9
+-Testing 123
++Testing ABC"""
+
+    SnapshotNotEqualErrorMsg.forUnequalStrings("Line\n123 Testing", "Line\nABC Testing") shouldBe
+        """Snapshot mismatch at L2:C1
+-123 Testing
++ABC Testing"""
+  }
+}

--- a/jvm/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/InteractiveTest.kt
+++ b/jvm/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/InteractiveTest.kt
@@ -37,9 +37,12 @@ class InteractiveTest : HarnessJUnit() {
   fun inlineMismatch() {
     ut_mirrorKt().lineWith("expectSelfie(").setContent("    expectSelfie(5).toBe(10)")
     gradleInteractiveFail().message shouldBe
-        "Snapshot mismatch\n" +
-            "- update this snapshot by adding `_TODO` to the function name\n" +
-            "- update all snapshots in this file by adding `//selfieonce` or `//SELFIEWRITE`"
+        """Snapshot mismatch at L1:C1
+-10
++5
+────────────────────
+- update this snapshot by adding `_TODO` to the function name
+- update all snapshots in this file by adding `//selfieonce` or `//SELFIEWRITE`"""
   }
 
   @Test @Order(3)

--- a/jvm/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/InteractiveTest.kt
+++ b/jvm/selfie-runner-junit5/src/test/kotlin/com/diffplug/selfie/junit5/InteractiveTest.kt
@@ -40,9 +40,8 @@ class InteractiveTest : HarnessJUnit() {
         """Snapshot mismatch at L1:C1
 -10
 +5
-────────────────────
-- update this snapshot by adding `_TODO` to the function name
-- update all snapshots in this file by adding `//selfieonce` or `//SELFIEWRITE`"""
+‣ update this snapshot by adding `_TODO` to the function name
+‣ update all snapshots in this file by adding `//selfieonce` or `//SELFIEWRITE`"""
   }
 
   @Test @Order(3)
@@ -75,8 +74,8 @@ class InteractiveTest : HarnessJUnit() {
     ut_mirrorKt().lineWith("expectSelfie(").setContent("    expectSelfie(\"5\").toMatchDisk()")
     gradleInteractiveFail().message shouldBe
         "Snapshot not found\n" +
-            "- update this snapshot by adding `_TODO` to the function name\n" +
-            "- update all snapshots in this file by adding `//selfieonce` or `//SELFIEWRITE`"
+            "‣ update this snapshot by adding `_TODO` to the function name\n" +
+            "‣ update all snapshots in this file by adding `//selfieonce` or `//SELFIEWRITE`"
   }
 
   @Test @Order(7)


### PR DESCRIPTION
When a snapshot fails, we now show the first failed line.