### PR TITLE
Off-by-one in the error message for a VCR key mismatch.

### DIFF
--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Off-by-one in the error message for a VCR key mismatch. ([#526](https://github.com/diffplug/selfie/pull/526))
 
 ## [2.5.1] - 2025-03-04
 ### Fixed

--- a/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/VcrSelfie.kt
+++ b/jvm/selfie-lib/src/commonMain/kotlin/com/diffplug/selfie/VcrSelfie.kt
@@ -111,7 +111,7 @@ internal constructor(
     val expected = state.frames[currentFrame]
     if (expected.first != key) {
       throw fs.assertFailed(
-          mode.msgVcrMismatch("$sub[$OPEN${currentFrame}$CLOSE]", expected.first, key, call),
+          mode.msgVcrMismatch("$sub[$OPEN${currentFrame+1}$CLOSE]", expected.first, key, call),
           expected.first,
           key)
     }


### PR DESCRIPTION
Super minor, but still wrong!